### PR TITLE
Add delete_document validation and unit test

### DIFF
--- a/backend/pdf_processing/document_service.py
+++ b/backend/pdf_processing/document_service.py
@@ -399,3 +399,13 @@ class DocumentService:
         except Exception as e:
             logger.exception(f"Error in structured financial data extraction: {e}")
             return {"error": str(e)}
+
+    async def delete_document(
+        self,
+        document_id: str,
+        analysis_repository: "AnalysisRepository",
+    ) -> bool:
+        """Delete a document unless referenced by an analysis."""
+        if await analysis_repository.is_document_referenced(document_id):
+            raise ValueError("Document is referenced by an analysis")
+        return await self.document_repository.delete_document(document_id)

--- a/backend/tests/unit/test_document_delete_endpoint.py
+++ b/backend/tests/unit/test_document_delete_endpoint.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routes.document import router, get_document_service, get_analysis_repository
+
+
+
+def create_client(doc_service_mock, analysis_repo_mock):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_document_service] = lambda: doc_service_mock
+    app.dependency_overrides[get_analysis_repository] = lambda: analysis_repo_mock
+    return TestClient(app)
+
+
+def test_delete_document_success():
+    doc_service = MagicMock()
+    doc_service.document_repository = MagicMock()
+    doc_service.document_repository.get_document = AsyncMock(return_value=object())
+    doc_service.delete_document = AsyncMock(return_value=True)
+    analysis_repo = MagicMock()
+
+    client = create_client(doc_service, analysis_repo)
+    response = client.delete("/api/documents/doc-1")
+    assert response.status_code == 200
+    doc_service.delete_document.assert_awaited_with("doc-1", analysis_repo)
+
+
+def test_delete_document_conflict():
+    doc_service = MagicMock()
+    doc_service.document_repository = MagicMock()
+    doc_service.document_repository.get_document = AsyncMock(return_value=object())
+    doc_service.delete_document = AsyncMock(side_effect=ValueError("Document is referenced by an analysis"))
+    analysis_repo = MagicMock()
+
+    client = create_client(doc_service, analysis_repo)
+    response = client.delete("/api/documents/doc-1")
+    assert response.status_code == 409
+    assert "referenced" in response.json()["detail"]
+


### PR DESCRIPTION
## Summary
- add `delete_document` method in DocumentService to block deletion if an analysis references the document
- exercise document removal via new endpoint test

## Testing
- `pytest tests/unit/test_document_delete_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683f61e867548332acc71a223f26aae7