### PR TITLE
Add table cell citation support

### DIFF
--- a/nextjs-fdas/src/components/tables/TableRenderer.tsx
+++ b/nextjs-fdas/src/components/tables/TableRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { TableData, TableColumn } from '@/types/visualization';
+import { Citation } from '@/types';
 import { formatValue } from '@/utils/formatters';
 
 interface TableRendererProps {
@@ -9,6 +10,7 @@ interface TableRendererProps {
   loading?: boolean;
   error?: Error | null;
   className?: string;
+  onCellClick?: (citation: Citation) => void;
 }
 
 /**
@@ -20,7 +22,8 @@ export default function TableRenderer({
   width = '100%',
   loading,
   error,
-  className = ''
+  className = '',
+  onCellClick
 }: TableRendererProps) {
   const [currentPage, setCurrentPage] = useState(0);
   
@@ -165,16 +168,30 @@ export default function TableRenderer({
                 )}
                 
                 {/* Cell data */}
-                {columns.map((column, colIndex) => (
-                  <td
-                    key={`cell-${rowIndex}-${colIndex}`}
-                    className={`px-3 py-4 whitespace-nowrap text-sm text-gray-500 ${
-                      column.align ? `text-${column.align}` : ''
-                    }`}
-                  >
-                    {formatCell(row[column.key], column)}
-                  </td>
-                ))}
+                {columns.map((column, colIndex) => {
+                  const cell = row[column.key];
+                  const citation = cell && typeof cell === 'object' && 'citation' in cell ? cell.citation : undefined;
+                  const value = cell && typeof cell === 'object' && 'value' in cell ? cell.value : cell;
+                  return (
+                    <td
+                      key={`cell-${rowIndex}-${colIndex}`}
+                      className={`px-3 py-4 whitespace-nowrap text-sm text-gray-500 ${
+                        column.align ? `text-${column.align}` : ''
+                      }`}
+                    >
+                      {citation && onCellClick ? (
+                        <button
+                          className="citation-link"
+                          onClick={() => onCellClick(citation)}
+                        >
+                          {formatCell(value, column)}
+                        </button>
+                      ) : (
+                        formatCell(value, column)
+                      )}
+                    </td>
+                  );
+                })}
               </tr>
             ))}
             

--- a/nextjs-fdas/src/components/visualization/Canvas.tsx
+++ b/nextjs-fdas/src/components/visualization/Canvas.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
-import { AnalysisResult } from '@/types';
+import { AnalysisResult, Citation } from '@/types';
 import { ChartData, TableData, VisualizationData, FinancialMetric } from '@/types/visualization';
 import ChartRenderer from '../charts/ChartRenderer';
 import TableRenderer from '../tables/TableRenderer';
@@ -157,6 +157,12 @@ const Canvas: React.FC<CanvasProps> = ({ analysisResults, messages = [], loading
 
   const visualizationData = processAnalysisResults(analysisResults, messages);
 
+  const handleCellClick = useCallback((citation: Citation) => {
+    if (onCitationClick) {
+      onCitationClick(citation.highlightId);
+    }
+  }, [onCitationClick]);
+
   if (loading) {
     return (
       <div role="status" aria-label="Loading visualizations" className="flex items-center justify-center p-8 bg-muted/20 rounded-lg min-h-[600px]">
@@ -254,7 +260,10 @@ const Canvas: React.FC<CanvasProps> = ({ analysisResults, messages = [], loading
             </div>
             
             {visualizationData.tables && visualizationData.tables.length > 0 && (
-              <TableRenderer data={visualizationData.tables[0]} />
+              <TableRenderer
+                data={visualizationData.tables[0]}
+                onCellClick={onCitationClick ? handleCellClick : undefined}
+              />
             )}
             
             {/* Display Analysis Text if available */}
@@ -282,7 +291,10 @@ const Canvas: React.FC<CanvasProps> = ({ analysisResults, messages = [], loading
               )) :
               (visualizationData.tables || []).map((table, index) => (
                 <div key={index} className="col-span-1">
-                  <TableRenderer data={table} />
+                  <TableRenderer
+                    data={table}
+                    onCellClick={onCitationClick ? handleCellClick : undefined}
+                  />
                 </div>
               ))
             }


### PR DESCRIPTION
## Summary
- allow TableRenderer to receive `onCellClick` and render citation buttons
- forward cell citations from Canvas to onCitationClick

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f646b61f483328178f03c4026919c