### PR TITLE
Add citation support to financial metric cards

### DIFF
--- a/nextjs-fdas/src/components/analysis/AnalysisBlock.tsx
+++ b/nextjs-fdas/src/components/analysis/AnalysisBlock.tsx
@@ -200,11 +200,13 @@ export const AnalysisBlock: React.FC<AnalysisBlockProps> = ({
             <DollarSign className="h-4 w-4 mr-1 text-blue-600" />
             Key Financial Metrics
           </h4>
-          <MetricGrid 
+          <MetricGrid
             metrics={block.metrics}
-            onMetricClick={(metric) => {
-              // Optional: Add any click handler for metrics
-              console.log('Metric clicked:', metric);
+            onMetricClick={(citation) => {
+              console.log('Metric clicked:', citation);
+              if (onCitationClick) {
+                onCitationClick(citation.highlightId);
+              }
             }}
           />
         </div>

--- a/nextjs-fdas/src/components/metrics/MetricCard.tsx
+++ b/nextjs-fdas/src/components/metrics/MetricCard.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
 import { formatValue, formatChange, getTrend } from '@/utils/formatters';
+import type { FinancialMetric, MetricCitation } from '@/types';
 
 interface MetricCardProps {
-  metric: {
-    name: string;
-    value: number;
-    unit?: string;
-    percentChange?: number;
-    previousValue?: number;
-    trend?: 'up' | 'down' | 'neutral';
-    category?: string;
-    description?: string;
-  };
+  metric: FinancialMetric;
   className?: string;
-  onClick?: () => void;
+  onClick?: (citation: MetricCitation) => void;
 }
 
 /**
@@ -92,9 +84,13 @@ export default function MetricCard({ metric, className = '', onClick }: MetricCa
   };
   
   return (
-    <div 
-      className={`metric-card ${className} ${onClick ? 'cursor-pointer hover:shadow-md' : ''}`}
-      onClick={onClick}
+    <div
+      className={`metric-card ${className} ${metric.citation && onClick ? 'cursor-pointer hover:shadow-md' : ''}`}
+      onClick={() => {
+        if (metric.citation && onClick) {
+          onClick(metric.citation);
+        }
+      }}
     >
       <div className="flex justify-between items-start">
         <h3 className="metric-card-title">{metric.name}</h3>

--- a/nextjs-fdas/src/components/metrics/MetricGrid.tsx
+++ b/nextjs-fdas/src/components/metrics/MetricGrid.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
-import { FinancialMetric } from '@/types/visualization';
+import { FinancialMetric, MetricCitation } from '@/types';
 import MetricCard from './MetricCard';
 
 interface MetricGridProps {
   metrics: FinancialMetric[];
   title?: string;
   subtitle?: string;
-  onMetricClick?: (metric: FinancialMetric) => void;
+  onMetricClick?: (citation: MetricCitation) => void;
 }
 
 /**
@@ -69,7 +69,11 @@ export default function MetricGrid({ metrics, title, subtitle, onMetricClick }: 
             <MetricCard
               key={`${metric.name}-${index}`}
               metric={metric}
-              onClick={onMetricClick ? () => onMetricClick(metric) : undefined}
+              onClick={
+                metric.citation && onMetricClick
+                  ? () => onMetricClick(metric.citation as MetricCitation)
+                  : undefined
+              }
             />
           ))}
         </div>

--- a/nextjs-fdas/src/types/index.ts
+++ b/nextjs-fdas/src/types/index.ts
@@ -120,6 +120,12 @@ export interface ConversationMetadata {
   session_id?: string; // For backward compatibility with backend response
 }
 
+export interface MetricCitation {
+  highlightId: string;
+  documentId: string;
+  page?: number;
+}
+
 export interface FinancialMetric {
   category: string;
   name: string;
@@ -127,6 +133,7 @@ export interface FinancialMetric {
   value: number;
   unit: string;
   isEstimated?: boolean;
+  citation?: MetricCitation;
 }
 
 // Added for Story # (Resolving linter error)

--- a/nextjs-fdas/src/types/visualization.ts
+++ b/nextjs-fdas/src/types/visualization.ts
@@ -120,4 +120,4 @@ export interface AnalysisResult {
   timestamp: string;
 }
 
-export type { FinancialMetric } from './index'; 
+export type { FinancialMetric, MetricCitation } from './index';


### PR DESCRIPTION
## Summary
- extend `FinancialMetric` with optional `MetricCitation`
- export `MetricCitation` in visualization types
- use `MetricCitation` in `MetricCard` and `MetricGrid`
- trigger metric click only when citation is present
- propagate clicks from `AnalysisBlock`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6465503483329f53d17da9ff5d7f