### PR TITLE
Add datapoint click handling for charts

### DIFF
--- a/nextjs-fdas/src/components/charts/AreaChart.tsx
+++ b/nextjs-fdas/src/components/charts/AreaChart.tsx
@@ -18,11 +18,19 @@ interface AreaChartProps {
   data: ChartData;
   height?: number | string;
   width?: number | string;
+  onDataPointClick?: (dataPoint: any) => void;
 }
 
-const AreaChart: React.FC<AreaChartProps> = ({ data, height = 400, width = '100%' }) => {
+const AreaChart: React.FC<AreaChartProps> = ({ data, height = 400, width = '100%', onDataPointClick }) => {
   const { config, data: chartData } = data;
   const dataKeys = chartData.length > 0 ? Object.keys(chartData[0]).filter(key => key !== 'name') : [];
+
+  const handleAreaClick = (event: any) => {
+    const payload = event?.payload;
+    if (payload?.citation && onDataPointClick) {
+      onDataPointClick(payload);
+    }
+  };
 
   if (!chartData || chartData.length === 0) {
     return (
@@ -144,7 +152,8 @@ const AreaChart: React.FC<AreaChartProps> = ({ data, height = 400, width = '100%
                   fillOpacity={1}
                   stackId={config.stacked ? 'stack' : undefined}
                   dot={config.showDots ?? false}
-                  activeDot={{ r: 6, stroke: color.stroke, strokeWidth: 2 }}
+                  activeDot={{ r: 6, stroke: color.stroke, strokeWidth: 2, onClick: handleAreaClick }}
+                  onClick={handleAreaClick}
                 />
               );
             })}

--- a/nextjs-fdas/src/components/charts/BarChart.tsx
+++ b/nextjs-fdas/src/components/charts/BarChart.tsx
@@ -18,19 +18,27 @@ interface BarChartProps {
   data: ChartData;
   height?: number | string;
   width?: number | string;
+  onDataPointClick?: (dataPoint: any) => void;
 }
 
 /**
  * BarChart component for rendering monetary values and comparing quantities
  * Uses Recharts library for rendering the chart
  */
-export default function BarChart({ data, height = 400, width = '100%' }: BarChartProps) {
+export default function BarChart({ data, height = 400, width = '100%', onDataPointClick }: BarChartProps) {
   const { config, chartConfig, data: rawChartData, chartType } = data;
   
   let processedData = rawChartData;
   // Expected categoryKey from config.xAxisKey or a fallback
-  const categoryKey = config.xAxisKey || 
+  const categoryKey = config.xAxisKey ||
                      (config.xAxisLabel ? config.xAxisLabel.toLowerCase().replace(/\s+/g, '_') : 'category');
+
+  const handleBarClick = (data: any) => {
+    const payload = data?.payload;
+    if (payload?.citation && onDataPointClick) {
+      onDataPointClick(payload);
+    }
+  };
 
   if (chartType === 'multiBar' && Array.isArray(rawChartData) && rawChartData.length > 0 && rawChartData[0].hasOwnProperty('name') && rawChartData[0].hasOwnProperty('data')) {
     // Transform data for multiBar:
@@ -77,6 +85,7 @@ export default function BarChart({ data, height = 400, width = '100%' }: BarChar
         stroke={metricConfig.color ? undefined : '#7066bb'}
         strokeWidth={1}
         radius={[4, 4, 0, 0]}
+        onClick={handleBarClick}
       />
     );
   });

--- a/nextjs-fdas/src/components/charts/ChartRenderer.tsx
+++ b/nextjs-fdas/src/components/charts/ChartRenderer.tsx
@@ -28,23 +28,23 @@ const ChartRenderer: React.FC<ChartRendererProps> = ({
   // Render the appropriate chart component based on chartType
   switch (chartType) {
     case 'bar':
-      return <BarChart data={data} />;
+      return <BarChart data={data} onDataPointClick={onDataPointClick} />;
     
     case 'multiBar':
-      return <BarChart data={data} />;
+      return <BarChart data={data} onDataPointClick={onDataPointClick} />;
     
     case 'line':
-      return <LineChart data={data} />;
+      return <LineChart data={data} onDataPointClick={onDataPointClick} />;
     
     case 'pie':
-      return <PieChart data={data} />;
+      return <PieChart data={data} onDataPointClick={onDataPointClick} />;
     
     case 'area':
     case 'stackedArea':
-      return <AreaChart data={data} />;
+      return <AreaChart data={data} onDataPointClick={onDataPointClick} />;
     
     case 'scatter':
-      return <ScatterChart data={data} />;
+      return <ScatterChart data={data} onDataPointClick={onDataPointClick} />;
     
     default:
       // Fallback to EnhancedChart for any other chart types

--- a/nextjs-fdas/src/components/charts/LineChart.tsx
+++ b/nextjs-fdas/src/components/charts/LineChart.tsx
@@ -18,15 +18,23 @@ interface LineChartProps {
   data: ChartData;
   height?: number | string;
   width?: number | string;
+  onDataPointClick?: (dataPoint: any) => void;
 }
 
 /**
  * LineChart component for rendering trends and time series data
  * Uses Recharts library for rendering the chart
  */
-export default function LineChart({ data, height = 400, width = '100%' }: LineChartProps) {
+export default function LineChart({ data, height = 400, width = '100%', onDataPointClick }: LineChartProps) {
   const { config, chartConfig, data: rawDataPointsFromBackend } = data;
   let processedData = rawDataPointsFromBackend;
+
+  const handleLineClick = (event: any) => {
+    const payload = event?.payload;
+    if (payload?.citation && onDataPointClick) {
+      onDataPointClick(payload);
+    }
+  };
 
   // Determine the key for the category axis (X-axis)
   // Prefer xAxisKey from config, fallback to a sanitized xAxisLabel, or default to 'category' or 'date'
@@ -67,7 +75,8 @@ export default function LineChart({ data, height = 400, width = '100%' }: LineCh
         stroke={CHART_COLORS[index % CHART_COLORS.length] || '#8884d8'}
         strokeWidth={2}
         dot={{ r: 3, strokeWidth: 1 }}
-        activeDot={{ r: 5, strokeWidth: 1 }}
+        activeDot={{ r: 5, strokeWidth: 1, onClick: handleLineClick }}
+        onClick={handleLineClick}
       />
     );
   });

--- a/nextjs-fdas/src/components/charts/MultiBarChart.tsx
+++ b/nextjs-fdas/src/components/charts/MultiBarChart.tsx
@@ -18,11 +18,19 @@ interface MultiBarChartProps {
   data: ChartData;
   height?: number | string;
   width?: number | string;
+  onDataPointClick?: (dataPoint: any) => void;
 }
 
-const MultiBarChart: React.FC<MultiBarChartProps> = ({ data, height = 400, width = '100%' }) => {
+const MultiBarChart: React.FC<MultiBarChartProps> = ({ data, height = 400, width = '100%', onDataPointClick }) => {
   const { config, data: chartData } = data;
   const dataKeys = chartData.length > 0 ? Object.keys(chartData[0]).filter(key => key !== 'name') : [];
+
+  const handleBarClick = (event: any) => {
+    const payload = event?.payload;
+    if (payload?.citation && onDataPointClick) {
+      onDataPointClick(payload);
+    }
+  };
 
   if (!chartData || chartData.length === 0) {
     return (
@@ -128,6 +136,7 @@ const MultiBarChart: React.FC<MultiBarChartProps> = ({ data, height = 400, width
                 radius={[4, 4, 0, 0]}
                 maxBarSize={60}
                 stackId={config.stacked ? 'stack' : undefined}
+                onClick={handleBarClick}
               />
             ))}
           </BarChart>

--- a/nextjs-fdas/src/components/charts/PieChart.tsx
+++ b/nextjs-fdas/src/components/charts/PieChart.tsx
@@ -7,10 +7,18 @@ interface PieChartProps {
   data: ChartData;
   height?: number | string;
   width?: number | string;
+  onDataPointClick?: (dataPoint: any) => void;
 }
 
-const PieChart: React.FC<PieChartProps> = ({ data, height = 400, width = '100%' }) => {
+const PieChart: React.FC<PieChartProps> = ({ data, height = 400, width = '100%', onDataPointClick }) => {
   const { config, data: chartData } = data;
+
+  const handleSliceClick = (event: any) => {
+    const payload = event?.payload;
+    if (payload?.citation && onDataPointClick) {
+      onDataPointClick(payload);
+    }
+  };
 
   if (!chartData || chartData.length === 0) {
     return (
@@ -49,6 +57,7 @@ const PieChart: React.FC<PieChartProps> = ({ data, height = 400, width = '100%' 
               label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
               labelLine={false}
               className="font-avenir-pro text-xs"
+              onClick={handleSliceClick}
             >
               {chartData.map((entry, index) => (
                 <Cell 

--- a/nextjs-fdas/src/components/charts/ScatterChart.tsx
+++ b/nextjs-fdas/src/components/charts/ScatterChart.tsx
@@ -19,13 +19,21 @@ interface ScatterChartProps {
   data: ChartData;
   height?: number | string;
   width?: number | string;
+  onDataPointClick?: (dataPoint: any) => void;
 }
 
 /**
  * Scatter Chart component for visualizing correlation between two variables
  */
-export default function ScatterChart({ data, height = 400, width = '100%' }: ScatterChartProps) {
+export default function ScatterChart({ data, height = 400, width = '100%', onDataPointClick }: ScatterChartProps) {
   const { config, data: chartData, chartConfig } = data;
+
+  const handlePointClick = (event: any) => {
+    const payload = event?.payload;
+    if (payload?.citation && onDataPointClick) {
+      onDataPointClick(payload);
+    }
+  };
   
   if (!chartData || chartData.length === 0) {
     return (
@@ -102,11 +110,12 @@ export default function ScatterChart({ data, height = 400, width = '100%' }: Sca
             <ReferenceLine x={0} stroke="#666" />
             <ReferenceLine y={0} stroke="#666" />
             
-            <Scatter 
-              name={config.title || "Data"} 
-              data={chartData} 
+            <Scatter
+              name={config.title || "Data"}
+              data={chartData}
               fill={CHART_COLORS[0]}
               aria-label={`Scatter plot points for ${config.title || 'data'}`}
+              onClick={handlePointClick}
             />
           </RechartsScatterChart>
         </ResponsiveContainer>

--- a/nextjs-fdas/src/components/visualization/Canvas.tsx
+++ b/nextjs-fdas/src/components/visualization/Canvas.tsx
@@ -22,6 +22,12 @@ interface CanvasProps {
 const Canvas: React.FC<CanvasProps> = ({ analysisResults, messages = [], loading, error, onCitationClick }) => {
   const [currentTab, setCurrentTab] = useState<'overview' | 'charts' | 'tables'>('overview');
 
+  const handleDataPointClick = (dataPoint: any) => {
+    if (dataPoint && dataPoint.citation && onCitationClick) {
+      onCitationClick(dataPoint.citation.highlightId);
+    }
+  };
+
   // NOTE: The following extensive regex-based extraction functions (extractFinancialDataFromMessages and its helpers)
   // have been removed as Canvas.tsx now relies solely on structured data (analysis_blocks or visualizationData)
   // from upstream sources (messages or analysisResults). This simplifies Canvas.tsx and removes brittle regex parsing.
@@ -246,10 +252,10 @@ const Canvas: React.FC<CanvasProps> = ({ analysisResults, messages = [], loading
             
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               {visualizationData.charts && visualizationData.charts.length > 0 && (
-                <ChartRenderer data={visualizationData.charts[0]} />
+                <ChartRenderer data={visualizationData.charts[0]} onDataPointClick={handleDataPointClick} />
               )}
               {visualizationData.charts && visualizationData.charts.length > 1 && (
-                <ChartRenderer data={visualizationData.charts[1]} />
+                <ChartRenderer data={visualizationData.charts[1]} onDataPointClick={handleDataPointClick} />
               )}
             </div>
             
@@ -277,7 +283,7 @@ const Canvas: React.FC<CanvasProps> = ({ analysisResults, messages = [], loading
             {currentTab === 'charts' ? 
               (visualizationData.charts || []).map((chart, index) => (
                 <div key={index} className="col-span-1">
-                  <ChartRenderer data={chart} />
+                  <ChartRenderer data={chart} onDataPointClick={handleDataPointClick} />
                 </div>
               )) :
               (visualizationData.tables || []).map((table, index) => (


### PR DESCRIPTION
## Summary
- support `onDataPointClick` in all chart components
- notify `Canvas` when chart items with citations are clicked
- wire up `ChartRenderer` to pass callbacks to charts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6477935c83329e2334893d32224e