### PR TITLE
Implement citation click callbacks in visualization components

### DIFF
--- a/nextjs-fdas/src/components/charts/ChartRenderer.tsx
+++ b/nextjs-fdas/src/components/charts/ChartRenderer.tsx
@@ -11,19 +11,31 @@ interface ChartRendererProps {
   data: ChartData;
   className?: string;
   onDataPointClick?: (dataPoint: any) => void;
+  /** Callback when a chart point citation is clicked */
+  onCitationClick?: (highlightId: string) => void;
 }
 
 /**
  * ChartRenderer component acts as a pure dispatcher for different chart types
  * It renders the appropriate chart component based on the chartType in the data
  */
-const ChartRenderer: React.FC<ChartRendererProps> = ({ 
-  data, 
+const ChartRenderer: React.FC<ChartRendererProps> = ({
+  data,
   className = '',
-  onDataPointClick
+  onDataPointClick,
+  onCitationClick
 }) => {
   // Extract chart type from data
   const { chartType } = data;
+
+  const handleDataPointClick = (point: any) => {
+    if (onDataPointClick) {
+      onDataPointClick(point);
+    }
+    if (onCitationClick && point && point.citation && point.citation.highlightId) {
+      onCitationClick(point.citation.highlightId);
+    }
+  };
 
   // Render the appropriate chart component based on chartType
   switch (chartType) {
@@ -59,10 +71,10 @@ const ChartRenderer: React.FC<ChartRendererProps> = ({
             </div>
           )}
           <div className="relative h-[300px]">
-            <EnhancedChart 
+            <EnhancedChart
               data={data.data}
               chartType={chartType}
-              onDataPointClick={onDataPointClick}
+              onDataPointClick={handleDataPointClick}
               height={300}
               xAxisTitle={data.config?.xAxisLabel}
               yAxisTitle={data.config?.yAxisLabel}

--- a/nextjs-fdas/src/components/metrics/MetricGrid.tsx
+++ b/nextjs-fdas/src/components/metrics/MetricGrid.tsx
@@ -7,13 +7,18 @@ interface MetricGridProps {
   title?: string;
   subtitle?: string;
   onMetricClick?: (metric: FinancialMetric) => void;
+  /**
+   * Callback fired when a metric with a citation is clicked.
+   * The metric object is expected to contain a `highlightId` property.
+   */
+  onCitationClick?: (highlightId: string) => void;
 }
 
 /**
  * MetricGrid component for organizing multiple metrics in a responsive grid layout
  * Includes filtering by category
  */
-export default function MetricGrid({ metrics, title, subtitle, onMetricClick }: MetricGridProps) {
+export default function MetricGrid({ metrics, title, subtitle, onMetricClick, onCitationClick }: MetricGridProps) {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   
   // Extract unique categories from metrics
@@ -69,7 +74,14 @@ export default function MetricGrid({ metrics, title, subtitle, onMetricClick }: 
             <MetricCard
               key={`${metric.name}-${index}`}
               metric={metric}
-              onClick={onMetricClick ? () => onMetricClick(metric) : undefined}
+              onClick={() => {
+                if (onMetricClick) {
+                  onMetricClick(metric);
+                }
+                if (onCitationClick && (metric as any).highlightId) {
+                  onCitationClick((metric as any).highlightId);
+                }
+              }}
             />
           ))}
         </div>

--- a/nextjs-fdas/src/components/tables/TableRenderer.tsx
+++ b/nextjs-fdas/src/components/tables/TableRenderer.tsx
@@ -9,6 +9,8 @@ interface TableRendererProps {
   loading?: boolean;
   error?: Error | null;
   className?: string;
+  /** Callback when a table row citation is clicked */
+  onCitationClick?: (highlightId: string) => void;
 }
 
 /**
@@ -20,7 +22,8 @@ export default function TableRenderer({
   width = '100%',
   loading,
   error,
-  className = ''
+  className = '',
+  onCitationClick
 }: TableRendererProps) {
   const [currentPage, setCurrentPage] = useState(0);
   
@@ -156,7 +159,15 @@ export default function TableRenderer({
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {currentRows.map((row, rowIndex) => (
-              <tr key={`row-${rowIndex}`} className={rowIndex % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+              <tr
+                key={`row-${rowIndex}`}
+                className={`${rowIndex % 2 === 0 ? 'bg-white' : 'bg-gray-50'} ${row?.citation?.highlightId ? 'cursor-pointer hover:bg-gray-100' : ''}`}
+                onClick={() => {
+                  if (onCitationClick && row?.citation?.highlightId) {
+                    onCitationClick(row.citation.highlightId);
+                  }
+                }}
+              >
                 {/* Row number if enabled */}
                 {config.showRowNumbers && (
                   <td className="px-3 py-4 whitespace-nowrap text-sm text-gray-500">

--- a/nextjs-fdas/src/components/visualization/Canvas.tsx
+++ b/nextjs-fdas/src/components/visualization/Canvas.tsx
@@ -157,6 +157,24 @@ const Canvas: React.FC<CanvasProps> = ({ analysisResults, messages = [], loading
 
   const visualizationData = processAnalysisResults(analysisResults, messages);
 
+  const handleMetricCitationClick = (metric: FinancialMetric) => {
+    if (onCitationClick && (metric as any).highlightId) {
+      onCitationClick((metric as any).highlightId);
+    }
+  };
+
+  const handleChartPointClick = (point: any) => {
+    if (onCitationClick && point?.citation?.highlightId) {
+      onCitationClick(point.citation.highlightId);
+    }
+  };
+
+  const handleTableCitationClick = (row: any) => {
+    if (onCitationClick && row?.citation?.highlightId) {
+      onCitationClick(row.citation.highlightId);
+    }
+  };
+
   if (loading) {
     return (
       <div role="status" aria-label="Loading visualizations" className="flex items-center justify-center p-8 bg-muted/20 rounded-lg min-h-[600px]">
@@ -239,22 +257,32 @@ const Canvas: React.FC<CanvasProps> = ({ analysisResults, messages = [], loading
       <div className="p-4 overflow-y-auto max-h-[calc(100vh-200px)]">
         {currentTab === 'overview' ? (
           <div className="space-y-6">
-            <MetricGrid 
+            <MetricGrid
               metrics={visualizationData.metrics || []}
               title="Key Performance Indicators"
+              onCitationClick={handleMetricCitationClick}
             />
             
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               {visualizationData.charts && visualizationData.charts.length > 0 && (
-                <ChartRenderer data={visualizationData.charts[0]} />
+                <ChartRenderer
+                  data={visualizationData.charts[0]}
+                  onCitationClick={handleChartPointClick}
+                />
               )}
               {visualizationData.charts && visualizationData.charts.length > 1 && (
-                <ChartRenderer data={visualizationData.charts[1]} />
+                <ChartRenderer
+                  data={visualizationData.charts[1]}
+                  onCitationClick={handleChartPointClick}
+                />
               )}
             </div>
             
             {visualizationData.tables && visualizationData.tables.length > 0 && (
-              <TableRenderer data={visualizationData.tables[0]} />
+              <TableRenderer
+                data={visualizationData.tables[0]}
+                onCitationClick={handleTableCitationClick}
+              />
             )}
             
             {/* Display Analysis Text if available */}
@@ -274,15 +302,21 @@ const Canvas: React.FC<CanvasProps> = ({ analysisResults, messages = [], loading
             aria-labelledby={`${currentTab}-tab`}
             className="grid grid-cols-1 lg:grid-cols-2 gap-4"
           >
-            {currentTab === 'charts' ? 
+            {currentTab === 'charts' ?
               (visualizationData.charts || []).map((chart, index) => (
                 <div key={index} className="col-span-1">
-                  <ChartRenderer data={chart} />
+                  <ChartRenderer
+                    data={chart}
+                    onCitationClick={handleChartPointClick}
+                  />
                 </div>
               )) :
               (visualizationData.tables || []).map((table, index) => (
                 <div key={index} className="col-span-1">
-                  <TableRenderer data={table} />
+                  <TableRenderer
+                    data={table}
+                    onCitationClick={handleTableCitationClick}
+                  />
                 </div>
               ))
             }


### PR DESCRIPTION
## Summary
- allow `MetricGrid`, `ChartRenderer` and `TableRenderer` to accept an `onCitationClick` prop
- add handlers in `Canvas` to pass citation highlights from metrics, charts and tables
- wire `Canvas` to pass the handlers to child components

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'vitest' and other type errors)*
- `npm test` *(fails: Jest tests fail due to missing modules and ResizeObserver)*

------
https://chatgpt.com/codex/tasks/task_e_683f648493e883329dcc386074638f57