### PR TITLE
Fix citation race conditions and stabilize chart rendering

### DIFF
--- a/nextjs-fdas/jest.setup.js
+++ b/nextjs-fdas/jest.setup.js
@@ -1,1 +1,9 @@
-import '@testing-library/jest-dom' 
+import '@testing-library/jest-dom'
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserver

--- a/nextjs-fdas/src/app/workspace/__tests__/page.test.tsx
+++ b/nextjs-fdas/src/app/workspace/__tests__/page.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Workspace from '../page';
+
+jest.mock('next/dynamic', () => {
+  return (importer: any) => {
+    const React = require('react');
+    return function DynamicMock(props: any) {
+      const [Comp, setComp] = React.useState<any>(null);
+      React.useEffect(() => {
+        Promise.resolve(importer()).then((mod: any) => setComp(() => mod.default || mod.CitationEnabledPDFViewer || mod));
+      }, []);
+      if (!Comp) return <div data-testid="pdf-viewer-loading" />;
+      return <Comp {...props} />;
+    };
+  };
+});
+
+jest.mock('@/context/CitationContext', () => ({
+  useCitation: () => ({
+    citations: new Map(),
+    addCitations: jest.fn(),
+    openCitation: jest.fn(),
+  }),
+}));
+
+jest.mock('@/lib/api/conversation', () => ({
+  conversationApi: {
+    createConversation: jest.fn().mockResolvedValue({ id: 'sess-1' }),
+    sendMessage: jest.fn().mockResolvedValue({ content: 'ok' }),
+  },
+}));
+
+jest.mock('@/lib/api/analysis', () => ({
+  analysisApi: {
+    runBasicFinancialAnalysis: jest.fn().mockResolvedValue({
+      id: 'analysis-1',
+      documentIds: ['doc-1'],
+      analysisType: 'basic_financial',
+      timestamp: new Date().toISOString(),
+      metrics: [],
+      visualizationData: { charts: [], tables: [] },
+      analysisText: 'summary',
+    }),
+    runAnalysis: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+jest.mock('@/components/analysis/AnalysisControls', () => ({
+  AnalysisControls: () => <div data-testid="analysis-controls" />,
+}));
+
+jest.mock('@/components/visualization/Canvas', () => () => <div data-testid="canvas" />);
+
+jest.mock('../../../components/document/UploadForm', () => ({
+  UploadForm: ({ onUploadSuccess }: any) => (
+    <button
+      type="button"
+      onClick={() =>
+        onUploadSuccess({
+          metadata: {
+            id: 'doc-1',
+            filename: 'test.pdf',
+            uploadTimestamp: new Date().toISOString(),
+            fileSize: 100,
+            mimeType: 'application/pdf',
+            userId: 'u1',
+          },
+          contentType: 'other',
+          extractionTimestamp: new Date().toISOString(),
+          periods: [],
+          extractedData: {},
+          confidenceScore: 1,
+          processingStatus: 'completed',
+          citations: [],
+        })
+      }
+    >
+      Complete Upload
+    </button>
+  ),
+}));
+
+jest.mock('../../../components/chat/StreamingChatInterface', () => ({
+  StreamingChatInterface: ({ onNavigateToHighlight }: any) => (
+    <button
+      type="button"
+      onClick={() =>
+        onNavigateToHighlight({
+          id: 'citation-id-1',
+          highlightId: 'highlight-id-1',
+          documentId: 'doc-1',
+          startPageNumber: 2,
+        })
+      }
+    >
+      Trigger Citation Click
+    </button>
+  ),
+}));
+
+jest.mock('../../../components/document/CitationEnabledPDFViewer', () => ({
+  CitationEnabledPDFViewer: ({ highlightId, document }: any) => (
+    <div data-testid="pdf-viewer" data-highlight-id={highlightId || ''} data-doc-id={document?.metadata?.id || ''} />
+  ),
+}));
+
+describe('Workspace citation navigation', () => {
+  test('clicking a chat citation routes to PDF viewer highlight id', async () => {
+    render(<Workspace />);
+
+    fireEvent.click(screen.getByRole('button', { name: /upload document/i }));
+    fireEvent.click(screen.getByRole('button', { name: /complete upload/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pdf-viewer')).toHaveAttribute('data-doc-id', 'doc-1');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /trigger citation click/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pdf-viewer')).toHaveAttribute('data-highlight-id', 'highlight-id-1');
+    });
+  });
+});

--- a/nextjs-fdas/src/app/workspace/page.tsx
+++ b/nextjs-fdas/src/app/workspace/page.tsx
@@ -594,6 +594,36 @@ export default function Workspace() {
     // Add streaming message to the messages map
     setMessagesMap(prev => {
       const existingMessage = prev[message.id];
+
+      const normalizeCitations = (citations?: Citation[]) => {
+        if (!Array.isArray(citations)) return [];
+        return citations
+          .map((c) => ({
+            id: c.id,
+            highlightId: c.highlightId || '',
+            page: c.startPageNumber || 0,
+            rectCount: c.rects?.length || 0,
+            text: (c.citedText || '').trim().toLowerCase().slice(0, 120)
+          }))
+          .sort((a, b) => {
+            const keyA = `${a.id}|${a.highlightId}|${a.page}|${a.rectCount}|${a.text}`;
+            const keyB = `${b.id}|${b.highlightId}|${b.page}|${b.rectCount}|${b.text}`;
+            return keyA.localeCompare(keyB);
+          });
+      };
+
+      const getAnalysisBlockFingerprint = (msg?: Message) => {
+        const blocks = ((msg as any)?.analysis_blocks || (msg as any)?.analysisBlocks || []) as any[];
+        return blocks
+          .map((block, idx) => {
+            const title = (block?.title || '').trim();
+            const type = block?.visualizationType || block?.type || 'unknown';
+            const tool = block?.tool_name || block?.toolName || '';
+            const points = Array.isArray(block?.data) ? block.data.length : 0;
+            return `${idx}:${type}:${tool}:${title}:${points}`;
+          })
+          .join('|');
+      };
       
       // For post-viz messages, tool messages, and no-result messages, check if already exists
       if (message.id.startsWith('post_viz_') || message.id.startsWith('tool_') || message.id.startsWith('no_result_')) {
@@ -612,21 +642,46 @@ export default function Workspace() {
         };
       }
       
-      // For regular streaming messages, only update if content changed, citations added, or analysis_blocks added
-      if (!existingMessage ||
-          existingMessage.content !== message.content ||
-          (message.citations && message.citations.length > 0 && !existingMessage.citations?.length) ||
-          (message.analysis_blocks && message.analysis_blocks.length > 0 && !(existingMessage as any).analysis_blocks?.length)) {
+      // For regular streaming messages, update whenever meaningful payload changed.
+      // This avoids race conditions where websocket text updates can overwrite or
+      // block later citation/analysis-block enrichment from backend polling.
+      const existingCitationFingerprint = JSON.stringify(normalizeCitations(existingMessage?.citations));
+      const incomingCitationFingerprint = JSON.stringify(normalizeCitations(message.citations));
+      const existingAnalysisFingerprint = getAnalysisBlockFingerprint(existingMessage);
+      const incomingAnalysisFingerprint = getAnalysisBlockFingerprint(message);
+
+      const contentChanged = !!existingMessage && existingMessage.content !== message.content;
+      const citationsChanged = existingCitationFingerprint !== incomingCitationFingerprint;
+      const analysisChanged = existingAnalysisFingerprint !== incomingAnalysisFingerprint;
+
+      if (!existingMessage || contentChanged || citationsChanged || analysisChanged) {
+        const mergedMessage: Message = {
+          ...(existingMessage || {}),
+          ...message,
+          // Preserve richer payloads when one side is empty; keep incoming when present.
+          citations:
+            Array.isArray(message.citations) && message.citations.length > 0
+              ? message.citations
+              : existingMessage?.citations || [],
+          analysis_blocks:
+            ((message as any).analysis_blocks && (message as any).analysis_blocks.length > 0)
+              ? (message as any).analysis_blocks
+              : ((existingMessage as any)?.analysis_blocks || [])
+        };
+
         console.log('[handleMessageUpdate] Updating message:', {
           messageId: message.id,
           hadCitations: !!existingMessage?.citations?.length,
           nowHasCitations: !!message.citations?.length,
           citationCount: message.citations?.length || 0,
-          contentChanged: existingMessage?.content !== message.content
+          contentChanged,
+          citationsChanged,
+          analysisChanged,
+          analysisBlockCount: ((mergedMessage as any).analysis_blocks || []).length
         });
         return {
           ...prev,
-          [message.id]: message
+          [message.id]: mergedMessage
         };
       }
       return prev; // No change needed
@@ -639,12 +694,14 @@ export default function Workspace() {
     if (citation) {
       // Use the citation ID (which might be a temp ID)
       // The PDFViewer has been updated to handle both temp IDs and UUIDs
+      const navigationHighlightId = citation.highlightId || citation.id;
       console.log('[WorkspacePage] handleNavigateToHighlight:', {
         citationId: citation.id,
         highlightId: citation.highlightId,
+        navigationHighlightId,
         page: citation.startPageNumber
       });
-      setHighlightId(citation.id);
+      setHighlightId(navigationHighlightId);
       setActiveTab('document');
     }
   }, []);

--- a/nextjs-fdas/src/components/charts/ChartRenderer.tsx
+++ b/nextjs-fdas/src/components/charts/ChartRenderer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { ChartData } from '@/types/visualization';
-import { EnhancedChart } from '../visualization/EnhancedChart';
 import BarChart from './BarChart';
 import LineChart from './LineChart';
 import PieChart from './PieChart';
@@ -9,9 +8,11 @@ import AreaChart from './AreaChart';
 import MultiBarChart from './MultiBarChart';
 
 interface ChartRendererProps {
-  data: ChartData;
+  data: ChartData | null;
   className?: string;
   onDataPointClick?: (dataPoint: any) => void;
+  loading?: boolean;
+  error?: Error | null;
 }
 
 /**
@@ -21,10 +22,37 @@ interface ChartRendererProps {
 const ChartRenderer: React.FC<ChartRendererProps> = ({ 
   data, 
   className = '',
-  onDataPointClick
+  onDataPointClick,
+  loading = false,
+  error = null
 }) => {
+  if (loading) {
+    return (
+      <div role="status" aria-label="Loading chart" className={`h-full flex items-center justify-center ${className}`}>
+        <span className="text-sm text-muted-foreground">Loading chart…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div role="alert" className={`h-full flex items-center justify-center ${className}`}>
+        <span className="text-sm text-red-600">{error.message}</span>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div role="status" aria-label="No chart data" className={`h-full flex items-center justify-center ${className}`}>
+        <span className="text-sm text-muted-foreground">No chart data available.</span>
+      </div>
+    );
+  }
+
   // Extract chart type from data
   const { chartType } = data;
+  const supportedChartTypes = new Set(['bar', 'multiBar', 'line', 'pie', 'area', 'stackedArea', 'scatter']);
 
   console.log('ChartRenderer - Data received:', {
     chartType,
@@ -36,86 +64,69 @@ const ChartRenderer: React.FC<ChartRendererProps> = ({
     chartConfigKeys: data.chartConfig ? Object.keys(data.chartConfig) : []
   });
 
+  if (!supportedChartTypes.has(chartType)) {
+    return (
+      <div role="alert" className={`h-full flex items-center justify-center ${className}`}>
+        <span className="text-sm text-red-600">Unsupported chart type: {chartType}</span>
+      </div>
+    );
+  }
+
   // Render the appropriate chart component based on chartType
   switch (chartType) {
     case 'bar':
       return (
-        <div className={`h-full flex justify-center ${className}`}>
+        <figure aria-label={data.config?.title || 'Bar Chart'} className={`h-full flex justify-center ${className}`}>
           <div className="w-full max-w-4xl">
             <BarChart data={data} height="100%" onDataPointClick={onDataPointClick} />
           </div>
-        </div>
+        </figure>
       );
     
     case 'multiBar':
       return (
-        <div className={`h-full flex justify-center ${className}`}>
+        <figure aria-label={data.config?.title || 'Multi Bar Chart'} className={`h-full flex justify-center ${className}`}>
           <div className="w-full max-w-4xl">
             <MultiBarChart data={data} height="100%" onDataPointClick={onDataPointClick} />
           </div>
-        </div>
+        </figure>
       );
     
     case 'line':
       return (
-        <div className={`h-full flex justify-center ${className}`}>
+        <figure aria-label={data.config?.title || 'Line Chart'} className={`h-full flex justify-center ${className}`}>
           <div className="w-full max-w-4xl">
             <LineChart data={data} height="100%" onDataPointClick={onDataPointClick} />
           </div>
-        </div>
+        </figure>
       );
     
     case 'pie':
       return (
-        <div className={`h-full flex justify-center ${className}`}>
+        <figure aria-label={data.config?.title || 'Pie Chart'} className={`h-full flex justify-center ${className}`}>
           <div className="w-full max-w-3xl">
             <PieChart data={data} height="100%" onDataPointClick={onDataPointClick} />
           </div>
-        </div>
+        </figure>
       );
     
     case 'area':
     case 'stackedArea':
       return (
-        <div className={`h-full flex justify-center ${className}`}>
+        <figure aria-label={data.config?.title || 'Area Chart'} className={`h-full flex justify-center ${className}`}>
           <div className="w-full max-w-4xl">
             <AreaChart data={data} height="100%" onDataPointClick={onDataPointClick} />
           </div>
-        </div>
+        </figure>
       );
     
     case 'scatter':
       return (
-        <div className={`h-full flex justify-center ${className}`}>
+        <figure aria-label={data.config?.title || 'Scatter Chart'} className={`h-full flex justify-center ${className}`}>
           <div className="w-full max-w-4xl">
             <ScatterChart data={data} height="100%" onDataPointClick={onDataPointClick} />
           </div>
-        </div>
-      );
-    
-    default:
-      // Fallback to EnhancedChart for any other chart types
-      return (
-        <div className={`bg-white rounded-lg shadow-sm p-4 h-full flex flex-col ${className}`}>
-          {data.config?.title && (
-            <div className="mb-4 flex-shrink-0">
-              <h3 className="text-lg font-semibold text-gray-900">{data.config.title}</h3>
-              {data.config.description && (
-                <p className="text-sm text-gray-500 mt-1">{data.config.description}</p>
-              )}
-            </div>
-          )}
-          <div className="relative flex-1 min-h-[300px]">
-            <EnhancedChart 
-              data={data.data}
-              chartType={chartType}
-              onDataPointClick={onDataPointClick}
-              height="100%"
-              xAxisTitle={data.config?.xAxisLabel}
-              yAxisTitle={data.config?.yAxisLabel}
-            />
-          </div>
-        </div>
+        </figure>
       );
   }
 };

--- a/nextjs-fdas/src/components/document/PDFViewer.tsx
+++ b/nextjs-fdas/src/components/document/PDFViewer.tsx
@@ -724,7 +724,8 @@ export function PDFViewer({
   }, [allHighlights]);
 
   // Keep one pending target and retry briefly until both highlight + viewer are ready.
-  // This matches the upstream scroll flow and avoids state-machine races.
+  // This mirrors the core react-pdf-highlighter jump-to-highlight pattern
+  // (scrollRef + deferred retries) to avoid race conditions between render and scroll.
   useEffect(() => {
     if (!highlightId) {
       pendingScrollHighlightIdRef.current = null;


### PR DESCRIPTION
### Motivation
- Prevent websocket streaming updates from clobbering backend-enriched citations and analysis blocks due to out-of-order arrivals.  
- Make jump-to-PDF navigation more reliable when temp citation IDs are replaced by backend IDs.  
- Stabilize chart rendering and tests (Recharts) by handling null/loading/error states and adding a jsdom-friendly `ResizeObserver` polyfill.

### Description
- Hardened message merge logic in `workspace/page.tsx` to compute fingerprints for citations and analysis blocks and merge incoming updates into an existing message rather than blindly replacing it, preserving richer payloads when available.  
- Prefer `citation.highlightId` (fall back to `citation.id`) for navigation and set the navigation target to that ID before switching to the Document tab to improve jump-to-PDF reliability.  
- Updated `src/components/charts/ChartRenderer.tsx` to accept `null` data and `loading`/`error` props, to return explicit `role` states (`status`/`alert`) for testability, and to use semantic `figure` wrappers and an explicit unsupported-type fallback.  
- Added a small `ResizeObserver` polyfill to `jest.setup.js` to stabilize Recharts tests under jsdom and added a clarifying comment in `PDFViewer.tsx` documenting the deferred scroll-retry pattern inspired by `react-pdf-highlighter` (scrollRef + retries) for race-resistant highlight jumps.

### Testing
- Ran `npm test -- --runInBand src/components/charts/__tests__/ChartRenderer.test.tsx src/components/document/__tests__/CitationEnabledPDFViewer.test.tsx` and both test suites passed.  
- Ran `npm test -- --runInBand src/components/visualization/__tests__/Canvas.test.tsx` which still fails due to existing Canvas test assumptions about missing `results` (failure not introduced by this change).  
- `npm run -s lint` was attempted but is blocked in this environment by the interactive Next.js ESLint setup prompt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5693d97c83329418e1fa32bc8433)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat message merge semantics and citation/highlight navigation, so regressions could surface as missing/duplicated citations or failed PDF jumps. Chart rendering now hard-fails unsupported types and introduces new loading/error/empty states, which may affect existing visualization flows.
> 
> **Overview**
> **Prevents citation/analysis enrichment from being lost during streaming chat updates.** `workspace/page.tsx` now detects meaningful changes via citation + analysis-block fingerprints and merges incoming message updates to preserve richer payloads instead of overwriting.
> 
> **Improves navigation and visualization/test stability.** Citation clicks now navigate via `citation.highlightId` (fallback `citation.id`) for more reliable PDF jumps; `ChartRenderer` now supports `null` data plus explicit loading/error/empty/unsupported-type states (and removes the `EnhancedChart` fallback); and `jest.setup.js` adds a minimal `ResizeObserver` polyfill for jsdom/Recharts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddd81d97ca860532a92ce6af622e586dcf80290c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->