### PR TITLE
Add Supabase storage and async Postgres database support

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ langgraph==0.2.43
 PyPDF2==3.0.1
 sqlalchemy==2.0.23
 psycopg2-binary==2.9.9
+asyncpg==0.29.0
 aiofiles==23.2.1
 aiosqlite==0.19.0
 psutil

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -10,8 +10,8 @@ ANTHROPIC_BETA = ",".join([
 
 # Claude model IDs
 # Keep overridable via environment so model rotations don't break local/dev runs.
-MODEL_HAIKU = os.getenv("MODEL_HAIKU", "claude-3-5-haiku-20241022")
-MODEL_SONNET = os.getenv("MODEL_SONNET", "claude-3-7-sonnet-20250219")
+MODEL_HAIKU = os.getenv("MODEL_HAIKU", "claude-haiku-4-5-20251001")
+MODEL_SONNET = os.getenv("MODEL_SONNET", "claude-sonnet-4-6")
 
 # Processing mode: 'fast' uses Haiku, 'detailed' uses Sonnet
 # Can be overridden by CLAUDE_PROCESSING_MODE environment variable

--- a/backend/utils/database.py
+++ b/backend/utils/database.py
@@ -1,29 +1,79 @@
 import os
 import sqlite3
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import declarative_base
+from sqlalchemy.pool import NullPool
 
 # Import sqlite3 error classes for aiosqlite
 import aiosqlite
 aiosqlite.DatabaseError = sqlite3.DatabaseError
 aiosqlite.Error = sqlite3.Error
 
-# Get the database URL from environment variables
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./fdas.db")
+def _postgres_to_asyncpg_url(url: str) -> str:
+    """Convert Supabase/Postgres URLs into a SQLAlchemy asyncpg URL."""
+    if url.startswith("postgres://"):
+        url = url.replace("postgres://", "postgresql://", 1)
 
-# Convert SQLite URL to work with SQLAlchemy asynchronous
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    elif url.startswith("postgresql+psycopg2://"):
+        url = url.replace("postgresql+psycopg2://", "postgresql+asyncpg://", 1)
+
+    parts = urlsplit(url)
+    query = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        # asyncpg expects ssl=require; Supabase pooler URLs commonly use sslmode=require.
+        if key == "sslmode":
+            query.append(("ssl", value))
+        else:
+            query.append((key, value))
+
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
+
+
+def _postgres_to_sync_url(url: str) -> str:
+    """Convert configured URLs into a psycopg2-compatible SQLAlchemy URL."""
+    if url.startswith("postgres://"):
+        url = url.replace("postgres://", "postgresql://", 1)
+    elif url.startswith("postgresql+asyncpg://"):
+        url = url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+    parts = urlsplit(url)
+    query = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        if key == "ssl":
+            query.append(("sslmode", value))
+        else:
+            query.append((key, value))
+
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
+
+
+# Get the database URL from environment variables
+RAW_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./fdas.db")
+DATABASE_URL = RAW_DATABASE_URL
+
+# Convert database URLs to work with SQLAlchemy asynchronous engines.
 if DATABASE_URL.startswith("sqlite"):
-    # For SQLite, we need to convert to the async variant
     DATABASE_URL = DATABASE_URL.replace("sqlite:///", "sqlite+aiosqlite:///", 1)
+elif DATABASE_URL.startswith(("postgres://", "postgresql://", "postgresql+psycopg2://", "postgresql+asyncpg://")):
+    DATABASE_URL = _postgres_to_asyncpg_url(DATABASE_URL)
 
 # Create async engine
-engine = create_async_engine(
-    DATABASE_URL,
-    echo=True if os.getenv("DEBUG") == "True" else False,
-    future=True,
-)
+engine_kwargs = {
+    "echo": True if os.getenv("DEBUG") == "True" else False,
+    "future": True,
+}
+
+if DATABASE_URL.startswith("postgresql+asyncpg"):
+    # Supabase recommends avoiding a second SQLAlchemy pool when using its pooler,
+    # which is also the right shape for serverless Vercel functions.
+    engine_kwargs["poolclass"] = NullPool
+
+engine = create_async_engine(DATABASE_URL, **engine_kwargs)
 
 # Create session factory
 SessionLocal = sessionmaker(
@@ -59,6 +109,6 @@ if DATABASE_URL.startswith("sqlite+aiosqlite"):
     SyncSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=sync_engine)
 else:
     # For PostgreSQL or other databases
-    sync_url = DATABASE_URL.replace("+asyncpg", "", 1) if "+asyncpg" in DATABASE_URL else DATABASE_URL
+    sync_url = _postgres_to_sync_url(DATABASE_URL)
     sync_engine = create_engine(sync_url)
     SyncSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=sync_engine)

--- a/backend/utils/init_db.py
+++ b/backend/utils/init_db.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.future import select
 
 from .database import engine, Base, SessionLocal
@@ -8,6 +9,9 @@ logger = logging.getLogger(__name__)
 
 async def create_tables():
     """Create database tables."""
+    # Ensure all SQLAlchemy model classes are registered with Base.metadata.
+    import models.database_models  # noqa: F401
+
     try:
         async with engine.begin() as conn:
             logger.info("Creating database tables...")
@@ -24,24 +28,33 @@ async def create_default_user():
     
     try:
         async with SessionLocal() as session:
-            # Check if any users exist
-            result = await session.execute(select(User).limit(1))
+            # API routes currently use this stable ID when auth is not present.
+            result = await session.execute(select(User).where(User.id == "default-user"))
             existing_user = result.scalars().first()
             
             if not existing_user:
-                logger.info("Creating default user...")
+                logger.info("Creating default API user...")
                 default_user = User(
-                    username="default",
-                    email="default@example.com",
+                    id="default-user",
+                    username="default-user",
+                    email="default-user@example.com",
                     hashed_password="notarealpassword",  # In a real app, this would be properly hashed
                     is_active=True
                 )
                 session.add(default_user)
-                await session.commit()
-                logger.info(f"Default user created with ID: {default_user.id}")
-                return default_user
+                try:
+                    await session.commit()
+                    logger.info(f"Default API user created with ID: {default_user.id}")
+                    return default_user
+                except IntegrityError:
+                    await session.rollback()
+                    result = await session.execute(select(User).where(User.id == "default-user"))
+                    existing_user = result.scalars().first()
+                    if existing_user:
+                        return existing_user
+                    raise
             
-            logger.info("Default user already exists.")
+            logger.info("Default API user already exists.")
             return existing_user
     except Exception as e:
         logger.error(f"Error creating default user: {str(e)}")

--- a/backend/utils/storage.py
+++ b/backend/utils/storage.py
@@ -43,12 +43,16 @@ Interactions with other files:
    - Routes document uploads through the storage layer
 
 This service is configurable through environment variables:
-- STORAGE_TYPE: "local" or "s3" to select the storage backend
+- STORAGE_TYPE: "local", "s3", or "supabase" to select the storage backend
 - UPLOAD_DIR: Directory for local file storage
 - S3_BUCKET_NAME: AWS S3 bucket for cloud storage
 - AWS_ACCESS_KEY_ID: AWS credentials for S3 access
 - AWS_SECRET_ACCESS_KEY: AWS credentials for S3 access
 - S3_REGION: AWS region for S3 bucket
+- SUPABASE_URL: Supabase project URL
+- SUPABASE_STORAGE_BUCKET: Supabase Storage bucket for document PDFs
+- SUPABASE_SECRET_KEY / SUPABASE_SERVICE_ROLE_KEY / SUPABASE_PUBLISHABLE_KEY:
+  API key used by the backend to access Supabase Storage
 
 The storage service layer ensures file operations are consistent regardless of
 the underlying storage mechanism, making the application more flexible and
@@ -58,9 +62,11 @@ easier to deploy in different environments.
 import os
 import io
 import aiofiles
+import httpx
 from typing import Optional
 import logging
 from abc import ABC, abstractmethod
+from urllib.parse import quote
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +100,8 @@ class StorageService(ABC):
         
         if storage_type == "s3":
             return S3StorageService()
+        if storage_type == "supabase":
+            return SupabaseStorageService()
         else:
             return LocalStorageService()
 
@@ -232,3 +240,126 @@ class S3StorageService(StorageService):
         """
         # For S3, we don't have a physical path, so return an S3 URL
         return f"s3://{self.bucket_name}/{file_id}"
+
+
+class SupabaseStorageService(StorageService):
+    """Storage service for Supabase Storage."""
+
+    def __init__(self):
+        self.supabase_url = os.getenv("SUPABASE_URL", "").rstrip("/")
+        if not self.supabase_url:
+            raise ValueError("SUPABASE_URL environment variable is not set")
+
+        self.bucket_name = os.getenv("SUPABASE_STORAGE_BUCKET", "cfin-documents")
+        self.api_key = (
+            os.getenv("SUPABASE_SECRET_KEY")
+            or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            or os.getenv("SUPABASE_SERVICE_KEY")
+            or os.getenv("SUPABASE_ANON_KEY")
+            or os.getenv("SUPABASE_PUBLISHABLE_KEY")
+        )
+        if not self.api_key:
+            raise ValueError(
+                "SUPABASE_SECRET_KEY, SUPABASE_SERVICE_ROLE_KEY, or "
+                "SUPABASE_PUBLISHABLE_KEY environment variable is not set"
+            )
+
+        self.timeout = httpx.Timeout(60.0, connect=10.0)
+
+    def _headers(self, content_type: Optional[str] = None) -> dict:
+        headers = {
+            "apikey": self.api_key,
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        if content_type:
+            headers["Content-Type"] = content_type
+        return headers
+
+    def _object_url(self, file_id: str) -> str:
+        bucket = quote(self.bucket_name, safe="")
+        object_path = quote(file_id.lstrip("/"), safe="/")
+        return f"{self.supabase_url}/storage/v1/object/{bucket}/{object_path}"
+
+    async def save_file(self, file_data: bytes, file_id: str, content_type: str) -> str:
+        """Save a file to Supabase Storage."""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    self._object_url(file_id),
+                    content=file_data,
+                    headers={
+                        **self._headers(content_type),
+                        "x-upsert": "true",
+                    },
+                )
+
+            if response.status_code not in {200, 201}:
+                raise RuntimeError(
+                    f"Supabase upload failed for {file_id}: "
+                    f"{response.status_code} {response.text[:300]}"
+                )
+
+            logger.info(f"File {file_id} uploaded to Supabase Storage")
+            return f"supabase://{self.bucket_name}/{file_id}"
+        except Exception as e:
+            logger.error(f"Error uploading file {file_id} to Supabase Storage: {str(e)}")
+            raise
+
+    async def get_file(self, file_id: str) -> Optional[bytes]:
+        """Get a file's contents from Supabase Storage."""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(
+                    self._object_url(file_id),
+                    headers=self._headers(),
+                )
+
+            if response.status_code == 404 or (
+                response.status_code == 400 and '"statusCode":"404"' in response.text
+            ):
+                logger.warning(f"File {file_id} not found in Supabase Storage")
+                return None
+
+            if response.status_code >= 400:
+                logger.error(
+                    f"Supabase download failed for {file_id}: "
+                    f"{response.status_code} {response.text[:300]}"
+                )
+                return None
+
+            return response.content
+        except Exception as e:
+            logger.error(f"Error downloading file {file_id} from Supabase Storage: {str(e)}")
+            return None
+
+    async def delete_file(self, file_id: str) -> bool:
+        """Delete a file from Supabase Storage."""
+        try:
+            delete_url = (
+                f"{self.supabase_url}/storage/v1/object/"
+                f"{quote(self.bucket_name, safe='')}"
+            )
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.request(
+                    "DELETE",
+                    delete_url,
+                    json={"prefixes": [file_id]},
+                    headers=self._headers("application/json"),
+                )
+
+            if response.status_code not in {200, 204}:
+                logger.error(
+                    f"Supabase delete failed for {file_id}: "
+                    f"{response.status_code} {response.text[:300]}"
+                )
+                return False
+
+            logger.info(f"File {file_id} deleted from Supabase Storage")
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting file {file_id} from Supabase Storage: {str(e)}")
+            return False
+
+    def get_file_path(self, file_id: str) -> str:
+        """Get the logical path to a file in Supabase Storage."""
+        return f"supabase://{self.bucket_name}/{file_id}"


### PR DESCRIPTION
## Summary
- Convert Postgres/Supabase URLs to async SQLAlchemy + asyncpg with SSL query normalization.
- Add Supabase Storage backend alongside local and S3.
- Harden default-user bootstrap and model registration during table creation.
- Add `asyncpg` dependency and update default Claude model IDs.

## Test plan
- [ ] Start backend with Supabase `DATABASE_URL` and confirm async engine connects.
- [ ] Upload/read a PDF via `STORAGE_TYPE=supabase`.
- [ ] Run `init_db` twice; default user creation should be idempotent.


Made with [Cursor](https://cursor.com)