### PR TITLE
Improve citation streaming markers and PDF fetch for highlights

### DIFF
--- a/backend/app/routes/conversation.py
+++ b/backend/app/routes/conversation.py
@@ -5,6 +5,7 @@ import logging
 import json
 import asyncio
 import re
+import uuid
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.message import ConversationCreateRequest, MessageRequest, MessageResponse
@@ -46,19 +47,31 @@ def _normalize_message_citations_for_markers(citations: List[Any], content: str)
     if markers:
         highest_marker = max(markers)
         if highest_marker > 0:
-            marker_citations = [
-                citation for citation in citations
-                if 0 < _citation_marker_index(citation) <= highest_marker
-            ]
-            if marker_citations:
-                marker_citations.sort(key=_citation_marker_index)
-                selected_citations = marker_citations[:highest_marker]
-            else:
-                # Older stored messages can have duplicate citation rows without
-                # persisted marker indexes. Preserve ordered duplicates here so
-                # marker [2] gets its own citation object and the rect finder can
-                # use marker-local answer context.
-                selected_citations = list(citations[:highest_marker])
+            marker_slots = [None] * highest_marker
+            remaining_citations: List[Any] = []
+
+            for citation in citations:
+                marker_index = _citation_marker_index(citation)
+                if 0 < marker_index <= highest_marker and marker_slots[marker_index - 1] is None:
+                    marker_slots[marker_index - 1] = citation
+                else:
+                    remaining_citations.append(citation)
+
+            # Some older rows have marker indexes for only the first few
+            # citations. Fill the missing marker slots from the remaining rows
+            # instead of returning a partial list and leaving visible markers
+            # such as [10]...[25] non-clickable.
+            selected_citations = []
+            remaining_iter = iter(remaining_citations)
+            for slot in marker_slots:
+                if slot is not None:
+                    selected_citations.append(slot)
+                    continue
+
+                try:
+                    selected_citations.append(next(remaining_iter))
+                except StopIteration:
+                    break
 
             for marker_index, citation in enumerate(selected_citations, start=1):
                 setattr(citation, "_marker_index_hint", marker_index)
@@ -741,6 +754,7 @@ async def get_message(
         
         # Get citations for this message
         citations = await conversation_service.conversation_repository.get_message_citations(message.id)
+        citations = _normalize_message_citations_for_markers(citations, message.content or "")
         
         # Convert citations to frontend-ready payloads, preserving backend IDs,
         # document IDs, and computed PDF rects for citation jump navigation.
@@ -811,63 +825,76 @@ async def send_message_streaming(
     
     async def generate_stream():
         """Generate streaming response as Server-Sent Events."""
+        event_queue = asyncio.Queue()
+        stream_message_id = str(uuid.uuid4())
+
+        async def emit_callback(event: Dict[str, Any]):
+            await event_queue.put(event)
+
+        async def run_processing():
+            try:
+                await emit_callback({
+                    "type": "message_start",
+                    "message_id": stream_message_id,
+                })
+
+                result = await conversation_service.process_user_message_streaming(
+                    conversation_id=session_id,
+                    content=message.content,
+                    citation_ids=message.citation_links,
+                    referenced_documents=message.referenced_documents,
+                    referenced_analyses=message.referenced_analyses,
+                    emit_callback=emit_callback,
+                    message_id=stream_message_id,
+                )
+
+                await emit_callback({
+                    "type": "message_complete",
+                    "success": result.get("success", True),
+                    "message_id": stream_message_id,
+                })
+
+            except ValueError as e:
+                await emit_callback({
+                    "type": "error",
+                    "error": "validation_error",
+                    "message": str(e),
+                    "message_id": stream_message_id,
+                })
+            except asyncio.TimeoutError:
+                logger.warning("Streaming message processing timed out for session %s", session_id)
+                await emit_callback({
+                    "type": "error",
+                    "error": "timeout_error",
+                    "message": "Streaming request timed out. Please retry with a narrower question.",
+                    "message_id": stream_message_id,
+                })
+            except Exception as e:
+                logger.exception(f"Error in streaming message processing: {str(e)}")
+                await emit_callback({
+                    "type": "error",
+                    "error": "server_error",
+                    "message": f"An error occurred while processing the message: {str(e)}",
+                    "message_id": stream_message_id,
+                })
+            finally:
+                await event_queue.put(None)
+
+        processing_task = asyncio.create_task(run_processing())
+
         try:
-            # Define callback for streaming events
-            async def emit_callback(event: Dict[str, Any]):
-                # Format as Server-Sent Event
-                event_data = json.dumps(event)
-                yield f"data: {event_data}\n\n"
-            
-            # Process the message with streaming
-            result = await conversation_service.process_user_message_streaming(
-                conversation_id=session_id,
-                content=message.content,
-                citation_ids=message.citation_links,
-                referenced_documents=message.referenced_documents,
-                referenced_analyses=message.referenced_analyses,
-                emit_callback=emit_callback
-            )
-            
-            # Send final completion event
-            message_obj = result.get("message", {})
-            message_id = None
-            if message_obj and hasattr(message_obj, 'id'):
-                message_id = str(message_obj.id)
-            elif message_obj and isinstance(message_obj, dict):
-                message_id = str(message_obj.get("id")) if message_obj.get("id") else None
-            
-            completion_event = {
-                "type": "message_complete",
-                "success": result.get("success", True),
-                "message_id": message_id
-            }
-            
-            yield f"data: {json.dumps(completion_event)}\n\n"
-            
-        except ValueError as e:
-            error_event = {
-                "type": "error",
-                "error": "validation_error",
-                "message": str(e)
-            }
-            yield f"data: {json.dumps(error_event)}\n\n"
-        except asyncio.TimeoutError:
-            logger.warning("Streaming message processing timed out for session %s", session_id)
-            error_event = {
-                "type": "error",
-                "error": "timeout_error",
-                "message": "Streaming request timed out. Please retry with a narrower question."
-            }
-            yield f"data: {json.dumps(error_event)}\n\n"
-            
-        except Exception as e:
-            logger.exception(f"Error in streaming message processing: {str(e)}")
-            error_event = {
-                "type": "error", 
-                "error": "server_error",
-                "message": f"An error occurred while processing the message: {str(e)}"
-            }
-            yield f"data: {json.dumps(error_event)}\n\n"
+            while True:
+                event = await event_queue.get()
+                if event is None:
+                    break
+                yield f"data: {json.dumps(event, default=str)}\n\n"
+        finally:
+            if not processing_task.done():
+                processing_task.cancel()
+                try:
+                    await processing_task
+                except asyncio.CancelledError:
+                    pass
     
     # Return streaming response with SSE headers
     return StreamingResponse(

--- a/backend/pdf_processing/api_service.py
+++ b/backend/pdf_processing/api_service.py
@@ -444,6 +444,18 @@ class ClaudeService:
         citation_counter = 0
         citation_positions = {}  # Map citation index to text position
         pending_citation_markers = []  # Queue for markers to inject
+        seen_citation_identities = set()
+
+        def _citation_identity(citation_data: Dict[str, Any]) -> tuple:
+            return (
+                citation_data.get("document_index"),
+                citation_data.get("document_title"),
+                citation_data.get("start_page_number"),
+                citation_data.get("end_page_number"),
+                citation_data.get("start_char_index"),
+                citation_data.get("end_char_index"),
+                (citation_data.get("cited_text") or "").strip()[:300],
+            )
         
         try:
             async with stream_manager as stream:
@@ -495,15 +507,27 @@ class ClaudeService:
                             # Citations need to be processed to extract searchable_text
                             # but markers will be added post-processing when citations are fully ready with rect data
                             process_citations_during_stream = True  # Enable citation processing
-                            inject_markers_during_stream = False    # But don't inject markers yet
+                            inject_markers_during_stream = True
                             
                             if inject_markers_during_stream:
                                 # Check if we have pending citation markers to inject
                                 # Always inject citations regardless of tool state
                                 if pending_citation_markers:
-                                    # Inject all pending markers at the end of this text chunk
+                                    # Claude emits citation_delta immediately after the cited span.
+                                    # Prepending pending markers to the next text chunk keeps the
+                                    # marker attached to the fact/value that came just before it.
+                                    markers_text = "".join(
+                                        marker_info['marker'] for marker_info in pending_citation_markers
+                                    )
+                                    joiner = (
+                                        " "
+                                        if text_delta
+                                        and not text_delta[0].isspace()
+                                        and text_delta[0] not in ".,;:)]}"
+                                        else ""
+                                    )
+                                    text_delta = f"{markers_text}{joiner}{text_delta}"
                                     for marker_info in pending_citation_markers:
-                                        text_delta += f" {marker_info['marker']}"
                                         logger.info(f"💉 Injected citation marker {marker_info['marker']} into stream")
                                         
                                         # Now emit the citation event with processed data
@@ -518,11 +542,11 @@ class ClaudeService:
                                             
                                             # Also emit citation delta with processed citation
                                             await emit_callback({
-                                            "type": "citations_delta",
-                                            "citation": marker_info['citation'],
-                                            "block_index": 0,
-                                            "message_id": message_id
-                                        })
+                                                "type": "citations_delta",
+                                                "citation": marker_info['citation'],
+                                                "block_index": 0,
+                                                "message_id": message_id
+                                            })
                                 
                                 # Clear pending markers
                                 pending_citation_markers.clear()
@@ -558,8 +582,18 @@ class ClaudeService:
                                 # Track post-tool text separately
                                 # Also check for pending markers in post-tool text
                                 if pending_citation_markers:
+                                    markers_text = "".join(
+                                        marker_info['marker'] for marker_info in pending_citation_markers
+                                    )
+                                    joiner = (
+                                        " "
+                                        if text_delta
+                                        and not text_delta[0].isspace()
+                                        and text_delta[0] not in ".,;:)]}"
+                                        else ""
+                                    )
+                                    text_delta = f"{markers_text}{joiner}{text_delta}"
                                     for marker_info in pending_citation_markers:
-                                        text_delta += f" {marker_info['marker']}"
                                         logger.info(f"💉 Injected citation marker {marker_info['marker']} into post-tool stream")
                                         
                                         # Emit events for post-tool citations
@@ -614,6 +648,7 @@ class ClaudeService:
                                 from utils.citation_processor import process_citation_for_granularity
                                 processed_citation = process_citation_for_granularity(citation_data)
                                 
+                                seen_citation_identities.add(_citation_identity(citation_data))
                                 citations.append(processed_citation)
                                 logger.info(f"📚 Citation {citation_index} processed during streaming: {processed_citation['type']} - '{processed_citation.get('cited_text', '')[:50]}...'")
                                 
@@ -630,11 +665,12 @@ class ClaudeService:
                                 
                                 # Don't emit citation_marker event yet - wait until text is ready
                                 
-                                # Still emit the original citation delta for compatibility
+                                # Emit the processed citation delta for compatibility. The
+                                # marker itself will be inserted into the next text delta.
                                 if emit_callback:
                                     await emit_callback({
                                         "type": "citations_delta",
-                                        "citation": citation_data,
+                                        "citation": processed_citation,
                                         "block_index": chunk.index if hasattr(chunk, 'index') else 0,
                                         "message_id": message_id
                                     })
@@ -761,11 +797,7 @@ class ClaudeService:
                                 # Process citations and inject markers into the text
                                 citation_markers_to_add = []
                                 for idx, citation in enumerate(content_block.citations):
-                                    # Increment citation counter
-                                    citation_counter += 1
-                                    citation_index = citation_counter
-                                    
-                                    citation_data = {
+                                    candidate_citation_data = {
                                         "type": citation.type,
                                         "cited_text": citation.cited_text,
                                         "document_index": citation.document_index,
@@ -776,8 +808,22 @@ class ClaudeService:
                                         "end_char_index": getattr(citation, 'end_char_index', None),
                                         "start_block_index": getattr(citation, 'start_block_index', None),
                                         "end_block_index": getattr(citation, 'end_block_index', None),
+                                        "citation_index": None
+                                    }
+
+                                    citation_identity = _citation_identity(candidate_citation_data)
+                                    if citation_identity in seen_citation_identities:
+                                        logger.info("⏩ Skipping duplicate final_message citation already seen during streaming")
+                                        continue
+
+                                    # Increment citation counter only for genuinely new citations.
+                                    citation_counter += 1
+                                    citation_index = citation_counter
+                                    citation_data = {
+                                        **candidate_citation_data,
                                         "citation_index": citation_index
                                     }
+                                    seen_citation_identities.add(citation_identity)
                                     
                                     # Process the citation immediately to extract specific values
                                     from utils.citation_processor import process_citation_for_granularity
@@ -810,24 +856,16 @@ class ClaudeService:
                                             "message_id": message_id
                                         })
                                 
-                                # Send citation markers as a text_delta to append to the streamed text
+                                # Do not emit a marker-only text_delta. The frontend attaches the
+                                # saved citations to the completed message and reflows missing
+                                # markers inline next to the matching facts. Emitting only
+                                # "[n] [n+1] ..." here creates a separate assistant bubble after
+                                # tool runs and makes citation jumps hard to follow.
                                 if citation_markers_to_add and emit_callback:
-                                    markers_text = " " + " ".join(citation_markers_to_add)
-                                    
-                                    # Send as text_delta to append to the initial streamed text
-                                    # IMPORTANT: Don't include accumulated_text to prevent content duplication
-                                    await emit_callback({
-                                        "type": "text_delta",
-                                        "text": markers_text,
-                                        "message_id": message_id
-                                    })
-                                    logger.info(f"💉 Sent {len(citation_markers_to_add)} citation markers as text_delta: {markers_text}")
-                                    
-                                    # Don't add citation markers to concluding_text - they belong to the pre-tool message
-                                    # concluding_text should only contain post-tool insights
-                                    
-                                    # Update accumulated_text to include the markers
-                                    accumulated_text += markers_text
+                                    logger.info(
+                                        "Processed %s final_message citations without emitting marker-only text_delta",
+                                        len(citation_markers_to_add),
+                                    )
                             elif hasattr(content_block, 'citations') and content_block.citations and len(citations) > 0:
                                 logger.info(f"Skipping {len(content_block.citations)} citations from final_message (already collected {len(citations)} during streaming)")
 
@@ -1022,7 +1060,7 @@ class ClaudeService:
             messages: List of message dictionaries with 'role' and 'content' keys
             temperature: Temperature for generation (0.0 to 1.0)
             max_tokens: Maximum number of tokens to generate
-            model: Optional model override (e.g., "claude-3-5-haiku-20241022")
+            model: Optional model override (e.g., settings.MODEL_HAIKU)
             stream: Whether to stream the response
             emit_callback: Optional callback for streaming events
             documents: Optional list of documents with claude_file_id for citation support
@@ -2516,8 +2554,23 @@ Follow these guidelines:
                 logger.info(f"📚 Adding {len(streaming_citations)} streaming citations to accumulated citations")
                 accumulated_citations.extend(streaming_citations)
 
+            deduped_accumulated_citations = []
+            seen_citation_keys = set()
+            for citation in accumulated_citations:
+                key = (
+                    citation.get("citation_index"),
+                    citation.get("document_index"),
+                    citation.get("start_page_number"),
+                    citation.get("end_page_number"),
+                    citation.get("cited_text"),
+                )
+                if key in seen_citation_keys:
+                    continue
+                seen_citation_keys.add(key)
+                deduped_accumulated_citations.append(citation)
+
             # Process citations for better granularity
-            processed_citations = process_citations_list(accumulated_citations)
+            processed_citations = process_citations_list(deduped_accumulated_citations)
             
             # Return structured result with initial text only
             result = {

--- a/backend/repositories/document_repository.py
+++ b/backend/repositories/document_repository.py
@@ -2171,7 +2171,13 @@ class DocumentRepository:
             if hasattr(document, 'binary_data') and document.binary_data:
                 return document.binary_data
             
-            # If we don't have binary data in the DB, try to read from file
+            # If we don't have binary data in the DB, read it from the configured
+            # storage backend. This covers Supabase/S3 as well as local storage.
+            stored_file = await self.storage_service.get_file(f"{document_id}.pdf")
+            if stored_file:
+                return stored_file
+
+            # Fall back to direct filesystem reads for legacy local paths.
             file_path = self.get_document_file_path(document_id)
             if os.path.exists(file_path):
                 with open(file_path, 'rb') as f:

--- a/backend/services/conversation_service.py
+++ b/backend/services/conversation_service.py
@@ -68,6 +68,7 @@ from repositories.document_repository import DocumentRepository
 from repositories.analysis_repository import AnalysisRepository
 from pdf_processing.api_service import ClaudeService
 from models.database_models import Message, Conversation, Citation
+import settings
 
 logger = logging.getLogger(__name__)
 
@@ -979,6 +980,26 @@ class ConversationService:
             nonlocal has_good_content, last_good_content, tool_start_processed_in_current_stream, initial_message_completed, waiting_for_citations, pending_citation_markers, highest_citation_marker, received_citation_markers, citation_completion_task
             
             event_type = event.get("type")
+            app_message_id = message_id if message_id else (
+                str(assistant_message_placeholder.id) if assistant_message_placeholder else "unknown"
+            )
+
+            # The transport layer already emits the app/database message_start.
+            # Passing through Anthropic's raw msg_* start event causes the client to
+            # split one assistant response across two IDs.
+            if event_type == "message_start" and not event.get("is_post_visualization"):
+                logger.info("Blocking nested Claude message_start; app message_start already emitted")
+                return
+
+            # Normalize initial-answer stream events to the database/app message id.
+            # Post-visualization and synthetic tool messages keep their own IDs.
+            if (
+                app_message_id
+                and event_type != "new_message_start"
+                and not event.get("is_post_visualization")
+                and not event.get("is_tools_message")
+            ):
+                event = {**event, "message_id": app_message_id}
 
             # Block early message_stop/message_complete events - we'll send our own when ready
             if (event_type in ["message_stop", "message_complete"]) and not event.get("is_post_tools") and not tool_start_processed_in_current_stream:
@@ -1366,25 +1387,18 @@ class ConversationService:
         # Skip citation injection if we already added markers during streaming
         if accumulated_citations:
             logger.info(f"Found {len(accumulated_citations)} citations")
-            
+
             # Check if markers were already injected during streaming
             has_streaming_markers = any(f"[{i+1}]" in final_content for i in range(len(accumulated_citations)))
-            
+
             if has_streaming_markers:
                 logger.info("✅ Citation markers already injected during streaming")
             else:
-                # Fallback: Add citations post-streaming (for non-streaming responses)
-                logger.info("Adding citation markers post-streaming (fallback)")
-                citation_summary = "\n\nSources:"
-                for idx, citation in enumerate(accumulated_citations):
-                    citation_summary += f"\n[{idx + 1}] {citation.get('document_title', 'Document')} - Page {citation.get('start_page_number', 'Page ?')}"
-                
-                final_content += citation_summary
-                
-                # Update the message with citation markers
-                assistant_message_placeholder.content = final_content
-                assistant_message = await self.conversation_repository.update_message(assistant_message_placeholder)
-                logger.info(f"✅ Updated content with citation markers: {len(final_content)} chars")
+                # Do not append a trailing "Sources:" marker block. The
+                # frontend renders every persisted citation inline beside
+                # matching facts; a backend-only marker list can drift from
+                # the saved citation count and create non-clickable markers.
+                logger.info("Leaving content marker-free; frontend will reflow persisted citations inline")
         
         logger.info(f"✅ Database updated with final content: {len(final_content)} chars")
         
@@ -1592,7 +1606,9 @@ class ConversationService:
                     visualizations=items_for_analysis_blocks
                 )
                 
-                # NOW send message_complete event after analysis blocks are stored atomically unless we already sent it earlier
+                # NOW send message_complete for the initial answer after analysis blocks
+                # are stored atomically unless we already sent it earlier. The tools
+                # carrier message is completed separately below.
                 if initial_message_completed:
                     logger.info(
                         "Skipping duplicate message_complete for initial message; it was already sent at first tool_start"
@@ -1620,6 +1636,17 @@ class ConversationService:
                     logger.warning(f"Failed to serialize analysis blocks for message_complete event: {ser_err}")
 
                 if emit_callback:
+                    if not initial_message_completed:
+                        await emit_callback({
+                            "type": "message_complete",
+                            "message_id": str(assistant_message.id),
+                            "timestamp": datetime.utcnow().isoformat() + 'Z',
+                            "citations": accumulated_citations,
+                            "is_post_tools": False,
+                            "is_post_visualization": False
+                        })
+                        initial_message_completed = True
+
                     # Send message_complete for the tools message
                     await emit_callback({
                         "type": "message_complete",
@@ -1985,14 +2012,14 @@ Conversation context:{document_context}
 
 Generate exactly {limit} follow-up questions, each on a new line, without numbering or bullet points. Make them conversational and specific to the context discussed."""
 
-            # Use Haiku 3.5 for fast, cost-effective follow-up generation
+            # Use the configured fast model for cost-effective follow-up generation.
             try:
                 follow_up_response_raw = await self._await_with_timeout(
                     "claude follow-up question generation",
                     self.claude_service.generate_response(
                         system_prompt="You are a financial analysis assistant that generates relevant follow-up questions for financial document discussions. Always provide exactly the requested number of questions, each on a separate line.",
                         messages=[{"role": "user", "content": follow_up_prompt}],
-                        model="claude-3-5-haiku-20241022",  # Use Haiku 3.5 as specified
+                        model=settings.MODEL_HAIKU,
                         max_tokens=500,  # Limit tokens since we only need a few questions
                         temperature=0.7,  # Slightly creative for varied questions
                     ),

--- a/backend/utils/citation_processor.py
+++ b/backend/utils/citation_processor.py
@@ -31,6 +31,27 @@ def extract_specific_value_from_citation(cited_text: str, page_number: Optional[
     lines = cited_text.strip().split('\n')
     
     logger.info(f"📊 Processing citation with {len(lines)} lines. First line: '{lines[0] if lines else ''}'")
+
+    # Earnings releases often cite compact "Metric of $X versus $Y" lines.
+    # Prefer the directly cited metric before trying generic table extraction,
+    # otherwise years such as 2023 can be misclassified as the value.
+    for line in lines:
+        metric_match = re.match(
+            r'^\s*([A-Za-z][A-Za-z\s,&\-/]+?)\s+of\s+'
+            r'(\$?[\d,]+(?:\.\d+)?\s*(?:million|billion|thousand)?)'
+            r'(?:\s+versus\s+(\$?[\d,]+(?:\.\d+)?\s*(?:million|billion|thousand)?))?',
+            line.strip(),
+            re.IGNORECASE,
+        )
+        if metric_match:
+            label = re.sub(r'\s+', ' ', metric_match.group(1)).strip()
+            current_value = metric_match.group(2).strip()
+            prior_value = metric_match.group(3).strip() if metric_match.group(3) else None
+            extracted = f"{label}: {current_value}"
+            if prior_value:
+                extracted += f" vs {prior_value}"
+            logger.info(f"📊 Extracted metric line from citation: '{extracted}'")
+            return extracted, True
     
     # Debug: Log first few lines to understand table structure
     if len(lines) > 3:


### PR DESCRIPTION
## Summary
- Stream citation markers adjacent to cited values and dedupe repeated citation events in `api_service.py`.
- Normalize SSE message IDs and block nested Claude `message_start` events in conversation streaming.
- Slot citation markers by index when hydrating stored messages.
- Prefer compact metric-line extraction in `citation_processor.py`.
- Load PDF bytes via storage backend in `document_repository.py` (requires stacked infra PR).

## Test plan
- [ ] Stream a chat response with citations; markers should appear inline without duplicate `[n]` markers.
- [ ] Reload a conversation; marker `[2]` should map to the second citation object.
- [ ] Click a citation on a Supabase-stored PDF; highlight rect should resolve.

## Stack
- Depends on #22 (`feat/supabase-async-storage`)


Made with [Cursor](https://cursor.com)