### PR TITLE
Improve frontend citation highlighting and streaming chat UX

### DIFF
--- a/nextjs-fdas/next.config.js
+++ b/nextjs-fdas/next.config.js
@@ -2,7 +2,7 @@
 const rawBackendApiUrl =
   process.env.NEXT_PUBLIC_API_URL ||
   process.env.API_BASE_URL ||
-  "https://cfin-api.aceanalytics.dev";
+  "https://cfin-backend.vercel.app";
 const backendApiBaseUrl = rawBackendApiUrl.replace(/\/+$/, "").replace(/\/api$/, "");
 
 const nextConfig = {
@@ -104,8 +104,12 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: "/api/citations/:path*",
-        destination: `${backendApiBaseUrl}/api/citations/:path*`,
+        source: "/api/:path*",
+        destination: `${backendApiBaseUrl}/api/:path*`,
+      },
+      {
+        source: "/ws/:path*",
+        destination: `${backendApiBaseUrl}/ws/:path*`,
       },
     ];
   },

--- a/nextjs-fdas/src/app/globals.css
+++ b/nextjs-fdas/src/app/globals.css
@@ -427,10 +427,12 @@ body.workspace-theme-active[data-direction='B'] {
 }
 
 .workspace-theme-shell .workspace-page {
-  height: calc(100dvh - 72px);
+  height: auto;
   min-height: calc(100vh - 72px);
   min-height: calc(100dvh - 72px);
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
   background:
     radial-gradient(1000px 420px at 8% -2%, color-mix(in srgb, hsl(var(--primary)) 14%, transparent), transparent 62%),
     radial-gradient(900px 380px at 92% 108%, color-mix(in srgb, hsl(var(--secondary)) 14%, transparent), transparent 58%),
@@ -479,15 +481,19 @@ body.workspace-theme-active[data-direction='B'] {
 }
 
 .workspace-theme-shell .workspace-grid {
+  flex: 0 0 auto;
   max-width: 1360px;
   width: 100%;
-  min-height: 0;
+  height: clamp(918px, calc(135dvh - 297px), 1069px);
+  max-height: 1069px;
+  min-height: 918px;
   margin: 0 auto;
   padding: 10px 24px 24px;
 }
 
 .workspace-theme-shell .workspace-panel {
   min-height: 0;
+  max-height: 100%;
   border: 1px solid var(--ws-line);
   border-radius: 18px;
   background: var(--ws-panel);
@@ -776,6 +782,12 @@ body.workspace-theme-active .fdas-textarea::placeholder {
   .workspace-theme-shell .workspace-grid {
     padding-left: 18px;
     padding-right: 18px;
+  }
+
+  .workspace-theme-shell .workspace-grid {
+    height: auto;
+    max-height: none;
+    min-height: 0;
   }
 }
  

--- a/nextjs-fdas/src/app/workspace/page.tsx
+++ b/nextjs-fdas/src/app/workspace/page.tsx
@@ -88,7 +88,7 @@ export default function Workspace() {
           setIsLoading(true);
           const params = new URLSearchParams(window.location.search);
           const requestedConversationId = params.get('conversationId') || params.get('sessionId');
-          const requestedDocumentId = params.get('documentId');
+          const requestedDocumentId = params.get('documentId') || params.get('document');
 
           if (requestedConversationId) {
             const conversationId = requestedConversationId;
@@ -123,12 +123,23 @@ export default function Workspace() {
             return;
           }
 
-          // Create a new conversation session
-          const response = await conversationApi.createConversation('New Conversation');
+          // Create a new conversation session, preserving a document deep-link if present.
+          const [response, document] = await Promise.all([
+            conversationApi.createConversation(
+              'New Conversation',
+              requestedDocumentId ? [requestedDocumentId] : [],
+            ),
+            requestedDocumentId
+              ? documentsApi.getDocument(requestedDocumentId)
+              : Promise.resolve(null),
+          ]);
           if (isCurrentRun()) {
             // The backend returns sessionId in camelCase due to alias_generator
             const sessionIdValue = response.sessionId || response.session_id;
             setSessionId(sessionIdValue);
+            if (document) {
+              setSelectedDocument(document);
+            }
             console.log('Created conversation session:', sessionIdValue);
           }
         } catch (error) {
@@ -772,7 +783,7 @@ export default function Workspace() {
   }, [addCitations]);
 
   return (
-    <div className="workspace-page flex h-[calc(100dvh-72px)] min-h-0 flex-col overflow-hidden">
+    <div className="workspace-page flex min-h-[calc(100dvh-72px)] flex-col overflow-x-hidden overflow-y-auto">
       <section className="workspace-overview">
         <p className="workspace-eyebrow">OP_APRT · CFIN WORKSPACE</p>
         <h1 className="workspace-title">Aperture Analysis Workspace</h1>

--- a/nextjs-fdas/src/components/chat/MessageRenderer.tsx
+++ b/nextjs-fdas/src/components/chat/MessageRenderer.tsx
@@ -11,6 +11,129 @@ interface MessageRendererProps {
   onCitationClick?: (citation: Citation) => void;
 }
 
+function uniqueTexts(values: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  values.forEach((value) => {
+    const normalized = (value || '').replace(/\s+/g, ' ').trim();
+    if (!normalized || seen.has(normalized.toLowerCase())) return;
+    seen.add(normalized.toLowerCase());
+    result.push(normalized);
+  });
+
+  return result;
+}
+
+function getCitationCandidates(citation: Citation): string[] {
+  const sourceTexts = uniqueTexts([
+    citation.displayText,
+    citation.citedText,
+    citation.searchableText,
+  ]);
+
+  const numericCandidates: string[] = [];
+  const numericPattern = /\$?\s?\d[\d,]*(?:\.\d+)?\s*(?:million|billion|thousand|basis points|bps|%)?/gi;
+
+  sourceTexts.forEach((text) => {
+    Array.from(text.matchAll(numericPattern)).forEach((match) => {
+      const candidate = match[0].replace(/\s+/g, ' ').replace(/^\$\s+/, '$').trim();
+      if (candidate.length < 2) return;
+      numericCandidates.push(candidate);
+      if (candidate.startsWith('$')) numericCandidates.push(candidate.slice(1));
+      if (candidate.includes(',')) numericCandidates.push(candidate.replace(/,/g, ''));
+    });
+  });
+
+  const nonYearNumeric = numericCandidates.filter(candidate => !/^20\d{2}$/.test(candidate));
+  const candidates = uniqueTexts([
+    ...nonYearNumeric,
+    ...sourceTexts.filter(text => text.length >= 4 && text.length <= 120),
+    ...numericCandidates,
+  ]);
+
+  return candidates.sort((a, b) => b.length - a.length);
+}
+
+function findCitationInsertionPoint(content: string, citation: Citation, startAt: number): number {
+  const lowerContent = content.toLowerCase();
+  const candidates = getCitationCandidates(citation);
+
+  const findFrom = (offset: number) => {
+    const matches = candidates
+      .map(candidate => {
+        const index = lowerContent.indexOf(candidate.toLowerCase(), offset);
+        return index >= 0 ? { index, length: candidate.length } : null;
+      })
+      .filter((match): match is { index: number; length: number } => Boolean(match));
+
+    if (!matches.length) return -1;
+    matches.sort((a, b) => (a.index - b.index) || (b.length - a.length));
+    return matches[0].index + matches[0].length;
+  };
+
+  const forwardMatch = findFrom(Math.max(0, startAt - 20));
+  if (forwardMatch >= 0) return forwardMatch;
+
+  return findFrom(0);
+}
+
+function reflowCitationMarkers(content: string, citations: Citation[]): string {
+  if (!content || citations.length === 0) return content;
+
+  const trailingMatch = content.match(/((?:\s*\[\d+\])+\s*)$/);
+  let body = trailingMatch && trailingMatch.index !== undefined
+    ? content.slice(0, trailingMatch.index).trimEnd()
+    : content;
+
+  const existingMarkers = new Set(
+    Array.from(body.matchAll(/\[(\d+)\]/g), match => Number(match[1]))
+  );
+  const trailingMarkers = trailingMatch
+    ? Array.from(trailingMatch[0].matchAll(/\[(\d+)\]/g), match => Number(match[1]))
+    : [];
+  const allCitationMarkers = citations.map((_, index) => index + 1);
+  const markersToPlace = Array.from(new Set([
+    ...trailingMarkers,
+    ...allCitationMarkers.filter(markerNumber => !existingMarkers.has(markerNumber)),
+  ])).sort((a, b) => a - b);
+
+  if (markersToPlace.length === 0) return content;
+
+  const insertions = new Map<number, string>();
+  const leftovers: string[] = [];
+  let searchFrom = 0;
+
+  markersToPlace.forEach((markerNumber) => {
+    const citation = citations[markerNumber - 1];
+    if (!citation) {
+      leftovers.push(`[${markerNumber}]`);
+      return;
+    }
+
+    const insertionPoint = findCitationInsertionPoint(body, citation, searchFrom);
+    if (insertionPoint < 0) {
+      leftovers.push(`[${markerNumber}]`);
+      return;
+    }
+
+    insertions.set(insertionPoint, `${insertions.get(insertionPoint) || ''}[${markerNumber}]`);
+    searchFrom = Math.max(searchFrom, insertionPoint);
+  });
+
+  const orderedInsertions = Array.from(insertions.entries()).sort((a, b) => b[0] - a[0]);
+  let reflowed = body;
+  orderedInsertions.forEach(([position, markerText]) => {
+    reflowed = `${reflowed.slice(0, position)}${markerText}${reflowed.slice(position)}`;
+  });
+
+  if (leftovers.length > 0) {
+    reflowed = `${reflowed} ${leftovers.join(' ')}`;
+  }
+
+  return reflowed;
+}
+
 // Custom equality function to prevent unnecessary re-renders
 function areEqual(prevProps: MessageRendererProps, nextProps: MessageRendererProps): boolean {
   const prevMsg = prevProps.message;
@@ -151,6 +274,7 @@ function MessageRendererBase({ message, onCitationClick }: MessageRendererProps)
   // the markers that were appended later in the stream.
 
   let processedContent = message.content;
+  processedContent = reflowCitationMarkers(processedContent, message.citations || []);
   const hasCitationMarkers = /\[\d+\]/.test(processedContent);
   
   // Handle the case where formatted content is followed by unformatted duplicate

--- a/nextjs-fdas/src/components/chat/StreamingChatInterface.tsx
+++ b/nextjs-fdas/src/components/chat/StreamingChatInterface.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/streaming-indicators';
 import { formatTimestamp } from '@/utils/formatters';
 import { useCitation } from '@/context/CitationContext';
+import { ENABLE_WEBSOCKET_STREAMING } from '@/lib/api/baseUrl';
 
 interface StreamingChatInterfaceProps {
   messages: Message[];
@@ -111,8 +112,7 @@ export function StreamingChatInterface({
       
       console.log(`Submit conditions: useStreaming=${useStreaming}, conversationId=${conversationId}, isConnected=${isConnected}`);
       
-      if (useStreaming && conversationId && isConnected) {
-        console.log('Using WebSocket streaming for message submission');
+      if (useStreaming && conversationId) {
         // Add user message to chat immediately for streaming
         const userMessage: Message = {
           id: `user-${Date.now()}`,
@@ -128,11 +128,16 @@ export function StreamingChatInterface({
         };
         onMessageUpdate?.(userMessage);
         
-        // Use streaming chat
-        try {
-          await sendStreamingMessage(inputValue);
-        } catch (streamingError) {
-          console.warn('WebSocket streaming failed, falling back to HTTP streaming:', streamingError);
+        if (ENABLE_WEBSOCKET_STREAMING && isConnected) {
+          console.log('Using WebSocket streaming for message submission');
+          try {
+            await sendStreamingMessage(inputValue);
+          } catch (streamingError) {
+            console.warn('WebSocket streaming failed, falling back to HTTP streaming:', streamingError);
+            await sendStreamingMessageHTTP(inputValue);
+          }
+        } else {
+          console.log('Using HTTP streaming for message submission');
           await sendStreamingMessageHTTP(inputValue);
         }
       } else {
@@ -307,8 +312,11 @@ export function StreamingChatInterface({
           <h2 className="text-base font-avenir-pro-demi text-foreground">Claude Assistant</h2>
           {conversationId && (
             <div className="flex items-center space-x-2">
-              <ConnectionStatus isConnected={isConnected} isStreaming={isStreaming} />
-              {useStreaming && !isConnected && (
+              <ConnectionStatus
+                isConnected={ENABLE_WEBSOCKET_STREAMING ? isConnected : useStreaming}
+                isStreaming={isStreaming}
+              />
+              {useStreaming && ENABLE_WEBSOCKET_STREAMING && !isConnected && (
                 <span className="text-xs text-muted-foreground">Connecting...</span>
               )}
               <button
@@ -399,9 +407,14 @@ export function StreamingChatInterface({
           </div>
           <button
             type="submit"
-            disabled={!inputValue.trim() || isSubmitting || (isStreaming && useStreaming) || (useStreaming && !isConnected)}
+            disabled={
+              !inputValue.trim() ||
+              isSubmitting ||
+              (isStreaming && useStreaming) ||
+              (useStreaming && ENABLE_WEBSOCKET_STREAMING && !isConnected)
+            }
             className="flex h-[44px] w-[44px] items-center justify-center rounded-full bg-primary p-3 text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-            title={useStreaming && !isConnected ? "Connecting to real-time chat..." : ""}
+            title={useStreaming && ENABLE_WEBSOCKET_STREAMING && !isConnected ? "Connecting to real-time chat..." : ""}
           >
             {isSubmitting || (isStreaming && useStreaming) ? (
               <Loader2 className="h-5 w-5 animate-spin" />

--- a/nextjs-fdas/src/components/document/PDFViewer.tsx
+++ b/nextjs-fdas/src/components/document/PDFViewer.tsx
@@ -14,6 +14,7 @@ import {
 } from "react-pdf-highlighter";
 import { documentsApi, cleanupBlobUrls } from '@/lib/api/documents';
 import { convertCitationToHighlight, convertHighlightToCitation } from '@/lib/pdf/citationService';
+import { searchMultiplePages } from '@/lib/pdf/textSearch';
 
 // Add PDF.js type declaration
 declare global {
@@ -52,7 +53,6 @@ export function PDFViewer({
   onCitationsLoaded,
   pdfUrl: propsPdfUrl,
   highlightId,
-  renderingQuality = 'medium',
   pageBufferSize = 5,
   extraCitations = []
 }: PDFViewerProps) {
@@ -62,13 +62,11 @@ export function PDFViewer({
   const [errorState, setErrorState] = useState<string | null>(error || null);
   const [loadingState, setLoadingState] = useState<string | null>(null);
   const [documentCitations, setDocumentCitations] = useState<Citation[]>([]);
+  const [searchResolvedCitations, setSearchResolvedCitations] = useState<Citation[]>([]);
   const [totalPages, setTotalPages] = useState<number>(0);
   const [visiblePages, setVisiblePages] = useState<number[]>([]);
   const [loadedPages, setLoadedPages] = useState<Set<number>>(new Set());
-  const [renderScale, setRenderScale] = useState<number>(
-    renderingQuality === 'low' ? 1.0 : 
-    renderingQuality === 'medium' ? 1.5 : 2.0
-  );
+  const [renderScale, setRenderScale] = useState<string>('page-fit');
   const [isBrowser, setIsBrowser] = useState(false);
   
   const [currentPdfDocument, setCurrentPdfDocument] = useState<any>(null);
@@ -209,7 +207,7 @@ export function PDFViewer({
   // Merge backend citations with any extra ones from props
   const combinedCitations = React.useMemo(() => {
     const byId = new Map<string, Citation>();
-    [...documentCitations, ...extraCitations].forEach((citation) => {
+    [...documentCitations, ...extraCitations, ...searchResolvedCitations].forEach((citation) => {
       const existing = byId.get(citation.id);
       if (!existing) {
         byId.set(citation.id, citation);
@@ -236,7 +234,7 @@ export function PDFViewer({
       });
     });
     return Array.from(byId.values());
-  }, [extraCitations, documentCitations]);
+  }, [extraCitations, documentCitations, searchResolvedCitations]);
 
   // Convert to react-pdf-highlighter format once
   const citationHighlights = React.useMemo(() => {
@@ -276,6 +274,83 @@ export function PDFViewer({
   useEffect(() => {
     combinedCitationsRef.current = combinedCitations;
   }, [combinedCitations]);
+
+  useEffect(() => {
+    if (!currentPdfDocument) return;
+    const transport = currentPdfDocument._transport || currentPdfDocument.transport;
+    if (transport && transport.messageHandler === null) return;
+
+    const candidates = combinedCitations.filter(
+      citation => !(citation.rects?.length > 0) && (citation.searchableText || citation.citedText)
+    );
+    if (candidates.length === 0) return;
+
+    let cancelled = false;
+
+    const buildSearchTerms = (citation: Citation) => {
+      const citedText = citation.citedText || '';
+      const numericTerms = Array.from(citedText.matchAll(/\$?\d[\d,]*(?:\.\d+)?/g))
+        .map(match => match[0].replace(/^\$/, ''))
+        .filter(term => term.length > 1 && !/^20\d{2}$/.test(term));
+
+      const textTerms = [
+        citation.searchableText,
+        citation.displayText,
+        citedText.split(/\r?\n/).find(line => line.trim().length > 0 && line.trim().length <= 120),
+        citedText,
+      ].filter((term): term is string => !!term && term.trim().length > 1);
+
+      return Array.from(new Set([...numericTerms, ...textTerms].map(term => term.trim()))).slice(0, 8);
+    };
+
+    const resolveMissingRects = async () => {
+      const resolved: Citation[] = [];
+
+      for (const citation of candidates) {
+        const startPage = citation.startPageNumber || 1;
+        const endPage = citation.endPageNumber || startPage;
+        const terms = buildSearchTerms(citation);
+
+        for (const term of terms) {
+          try {
+            const results = await searchMultiplePages(currentPdfDocument, term, startPage, endPage);
+            const result = results[0];
+            if (!result?.rects?.length) continue;
+
+            const rects = result.rects.map(rect => ({
+              ...rect,
+              width: rect.x2 - rect.x1,
+              height: rect.y2 - rect.y1,
+              pageNumber: rect.pageNumber,
+            }));
+
+            resolved.push({
+              ...citation,
+              searchableText: term,
+              rects,
+            });
+            break;
+          } catch (error) {
+            console.warn('[PDFViewer] Citation text search failed:', { citationId: citation.id, term, error });
+          }
+        }
+      }
+
+      if (cancelled || resolved.length === 0) return;
+
+      setSearchResolvedCitations(prev => {
+        const byId = new Map(prev.map(citation => [citation.id, citation]));
+        resolved.forEach(citation => byId.set(citation.id, citation));
+        return Array.from(byId.values());
+      });
+    };
+
+    resolveMissingRects();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [combinedCitations, currentPdfDocument]);
   
   // Memory management: Page visibility tracking
   const onVisiblePagesChanged = useCallback((pages?: number[]) => {
@@ -840,14 +915,11 @@ export function PDFViewer({
     };
   }, [highlightId, scrollToHighlight, highlightScrollVersion, getHighlightElement, isElementVisibleInViewport]);
   
-  // Update render scale when renderingQuality changes
+  // Reset each newly loaded PDF to fit one full page inside the viewer.
   useEffect(() => {
     if (!isBrowser) return;
-    setRenderScale(
-      renderingQuality === 'low' ? 1.0 : 
-      renderingQuality === 'medium' ? 1.5 : 2.0
-    );
-  }, [renderingQuality, isBrowser]);
+    setRenderScale('page-fit');
+  }, [document?.metadata.id, propsPdfUrl, isBrowser]);
   
   // Cleanup on unmount
   useEffect(() => {
@@ -1100,7 +1172,7 @@ export function PDFViewer({
                   }}
                   highlights={allHighlights}
                   highlightTransform={renderHighlight as any}
-                  pdfScaleValue={renderScale.toString()}
+                  pdfScaleValue={renderScale}
                 />
               );
             }}
@@ -1114,20 +1186,26 @@ export function PDFViewer({
           <div className="mb-1 font-medium text-foreground">Performance Options</div>
           <div className="flex space-x-2">
             <button 
-              className={`rounded-full px-3 py-1 ${renderingQuality === 'low' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
-              onClick={() => setRenderScale(1.0)}
+              className={`rounded-full px-3 py-1 ${renderScale === 'page-fit' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
+              onClick={() => setRenderScale('page-fit')}
+            >
+              Fit
+            </button>
+            <button 
+              className={`rounded-full px-3 py-1 ${renderScale === '1' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
+              onClick={() => setRenderScale('1')}
             >
               Low
             </button>
             <button 
-              className={`rounded-full px-3 py-1 ${renderingQuality === 'medium' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
-              onClick={() => setRenderScale(1.5)}
+              className={`rounded-full px-3 py-1 ${renderScale === '1.5' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
+              onClick={() => setRenderScale('1.5')}
             >
               Medium
             </button>
             <button 
-              className={`rounded-full px-3 py-1 ${renderingQuality === 'high' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
-              onClick={() => setRenderScale(2.0)}
+              className={`rounded-full px-3 py-1 ${renderScale === '2' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
+              onClick={() => setRenderScale('2')}
             >
               High
             </button>

--- a/nextjs-fdas/src/context/CitationContext.tsx
+++ b/nextjs-fdas/src/context/CitationContext.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useContext, useState, useCallback, ReactNode } fr
 import { Citation, CitationPayload } from '@/types/citation';
 import { ProcessedDocument } from '@/types';
 import { getCitationCache } from '@/lib/cache/citationCache';
+import { apiUrl } from '@/lib/api/baseUrl';
 
 interface CitationContextType {
   citations: Map<string, Citation>;
@@ -57,9 +58,7 @@ export const CitationProvider: React.FC<CitationProviderProps> = ({ children }) 
 
     console.log('[CitationContext] loadCitation fetching from API', { citationId });
     try {
-      // Use backend API URL
-      const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-      const response = await fetch(`${API_BASE_URL}/api/citations/${citationId}`);
+      const response = await fetch(apiUrl(`/api/citations/${citationId}`));
       if (!response.ok) {
         throw new Error(`Failed to load citation: ${response.statusText}`);
       }
@@ -89,9 +88,7 @@ export const CitationProvider: React.FC<CitationProviderProps> = ({ children }) 
 
     console.log('[CitationContext] loadDocument fetching from API', { documentId });
     try {
-      // Use backend API URL
-      const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-      const response = await fetch(`${API_BASE_URL}/api/documents/${documentId}`);
+      const response = await fetch(apiUrl(`/api/documents/${documentId}`));
       if (!response.ok) {
         throw new Error(`Failed to load document: ${response.statusText}`);
       }
@@ -110,8 +107,7 @@ export const CitationProvider: React.FC<CitationProviderProps> = ({ children }) 
   }, [documents]);
 
   const getDocumentUrl = useCallback((documentId: string): string => {
-    const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-    return `${API_BASE_URL}/api/documents/${documentId}/file`;
+    return apiUrl(`/api/documents/${documentId}/file`);
   }, []);
 
   const openCitation = useCallback(async (citationId: string): Promise<void> => {

--- a/nextjs-fdas/src/hooks/useStreamingChat.ts
+++ b/nextjs-fdas/src/hooks/useStreamingChat.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { Message } from '@/types';
 import { conversationApi } from '@/lib/api/conversation';
+import { ENABLE_WEBSOCKET_STREAMING, apiUrl, websocketUrl } from '@/lib/api/baseUrl';
 
 export interface StreamingEvent {
   type: 'message_start' | 'text_delta' | 'tool_start' | 'tool_complete' | 
@@ -602,6 +603,13 @@ export function useStreamingChat({
 
   // WebSocket streaming
   const connectWebSocket = useCallback(async (shouldReconnect = true) => {
+    if (!ENABLE_WEBSOCKET_STREAMING) {
+      console.log('WebSocket streaming disabled for this backend; using HTTP streaming fallback');
+      setIsConnected(false);
+      isConnectingRef.current = false;
+      return;
+    }
+
     // Don't try to connect if no conversationId
     if (!conversationId) {
       console.warn('Cannot connect WebSocket without conversation ID');
@@ -640,15 +648,7 @@ export function useStreamingChat({
         isConnectingRef.current = false;
         return;
       }
-      // Get the backend URL from environment or use default
-      const backendHost = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-      const backendUrl = new URL(backendHost);
-      
-      // Determine WebSocket protocol based on backend protocol
-      const protocol = backendUrl.protocol === 'https:' ? 'wss:' : 'ws:';
-      
-      // Construct WebSocket URL pointing to the backend server
-      const wsUrl = `${protocol}//${backendUrl.hostname}:${backendUrl.port || (backendUrl.protocol === 'https:' ? '443' : '8000')}/ws/conversation/${conversationId}`;
+      const wsUrl = websocketUrl(`/ws/conversation/${conversationId}`);
       
       console.log('Starting WebSocket connection to:', wsUrl);
       console.log('Current isConnected state before connection:', isConnected);
@@ -718,7 +718,7 @@ export function useStreamingChat({
     }
 
     try {
-      const sseUrl = `/api/conversation/${conversationId}/message/stream`;
+      const sseUrl = apiUrl(`/api/conversation/${conversationId}/message/stream`);
       eventSourceRef.current = new EventSource(sseUrl);
 
       eventSourceRef.current.onopen = () => {
@@ -774,7 +774,7 @@ export function useStreamingChat({
   // Send streaming message via HTTP (fallback)
   const sendStreamingMessageHTTP = useCallback(async (content: string) => {
     try {
-      const response = await fetch(`/api/conversation/${conversationId}/message/stream`, {
+      const response = await fetch(apiUrl(`/api/conversation/${conversationId}/message/stream`), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -832,7 +832,7 @@ export function useStreamingChat({
     let mounted = true;
     let connectTimeout: NodeJS.Timeout | null = null;
 
-    if (conversationId && mounted) {
+    if (conversationId && mounted && ENABLE_WEBSOCKET_STREAMING) {
       // Add a small delay to debounce rapid re-renders
       connectTimeout = setTimeout(() => {
         if (mounted) {

--- a/nextjs-fdas/src/hooks/useStreamingChatWithCitations.ts
+++ b/nextjs-fdas/src/hooks/useStreamingChatWithCitations.ts
@@ -5,6 +5,7 @@ import { Message, Citation } from '@/types';
 import { ClaudeCitation } from '@/types/citation';
 import { conversationApi } from '@/lib/api/conversation';
 import { useCitation } from '@/context/CitationContext';
+import { ENABLE_WEBSOCKET_STREAMING, apiUrl, websocketUrl } from '@/lib/api/baseUrl';
 // (no placeholder imports)
 
 export interface StreamingEvent {
@@ -202,6 +203,22 @@ export function useStreamingChatWithCitations({
         
         // Check if this text contains citation markers (e.g., [1], [2], etc.)
         const containsCitationMarkers = /\[\d+\]/.test(event.text);
+        const isCitationMarkerOnly = /^\s*(?:\[\d+\]\s*)+$/.test(event.text);
+
+        if (isCitationMarkerOnly && !event.is_post_visualization) {
+          const existingInitialText = `${streamingTextRef.current}\n${frozenInitialTextRef.current}`;
+          const missingMarkers = Array.from(event.text.matchAll(/\[(\d+)\]/g))
+            .map(match => `[${match[1]}]`)
+            .filter(marker => !existingInitialText.includes(marker));
+
+          if (missingMarkers.length > 0) {
+            const markerText = ` ${missingMarkers.join(' ')}`;
+            console.log('Late citation marker-only delta mapped back to initial answer:', markerText);
+            appendToFrozenInitial(markerText);
+            appendToStreamingText(markerText);
+          }
+          return;
+        }
         
         // 1) If this text belongs to a *known* post-viz message, append to it.
         if (event.message_id && event.message_id === postToolMessageId && onMessageUpdate) {
@@ -579,6 +596,7 @@ export function useStreamingChatWithCitations({
             return content;
           };
           finalContent = deduplicate(finalContent);
+          const finalContentWasEmpty = finalContent.trim().length === 0;
           
           // Log the final content for debugging
           console.log('Final streamed content:', {
@@ -620,14 +638,15 @@ export function useStreamingChatWithCitations({
           // Then, fetch additional data (analysis blocks and citations) from backend
           // We'll batch these updates to avoid multiple onMessageUpdate calls
           
-          const expectedCitationCount = (() => {
-            const markerMatches = Array.from((originalContent || '').matchAll(/\[(\d+)\]/g));
-            if (markerMatches.length === 0) return 0;
-            return markerMatches.reduce((max, match) => {
-              const marker = Number(match[1] || 0);
-              return Number.isFinite(marker) ? Math.max(max, marker) : max;
-            }, 0);
-          })();
+	          const expectedCitationCount = (() => {
+	            const markerMatches = Array.from((originalContent || '').matchAll(/\[(\d+)\]/g));
+	            if (markerMatches.length === 0) return 0;
+	            return markerMatches.reduce((max, match) => {
+	              const marker = Number(match[1] || 0);
+	              return Number.isFinite(marker) ? Math.max(max, marker) : max;
+	            }, 0);
+	          })();
+	          const eventCitationCount = Array.isArray(event.citations) ? event.citations.length : 0;
 
           const fetchAnalysisBlocksAndCitations = async () => {
             try {
@@ -724,6 +743,11 @@ export function useStreamingChatWithCitations({
                 content_blocks: message.content_blocks || [],
                 analysis_blocks: message.analysis_blocks || []
               };
+
+              if (backendMessage.content && (!updatedMessage.content || updatedMessage.content.trim().length === 0)) {
+                updatedMessage.content = backendMessage.content;
+                needsUpdate = true;
+              }
               
               // Check for analysis blocks
               if (hadTools && backendMessage.analysis_blocks && backendMessage.analysis_blocks.length > 0) {
@@ -865,7 +889,7 @@ export function useStreamingChatWithCitations({
           };
           
           // Only fetch backend data if we need it
-          const shouldFetchBackendData = hadTools || expectedCitationCount > 0;
+	          const shouldFetchBackendData = hadTools || expectedCitationCount > 0 || finalContentWasEmpty || eventCitationCount > 0;
           if (shouldFetchBackendData) {
             // Clear any existing timeout
             if (pendingFetchTimeoutRef.current) {
@@ -932,6 +956,13 @@ export function useStreamingChatWithCitations({
 
   // WebSocket streaming
   const connectWebSocket = useCallback(async (shouldReconnect = true) => {
+    if (!ENABLE_WEBSOCKET_STREAMING) {
+      console.log('WebSocket streaming disabled for this backend; using HTTP streaming fallback');
+      setIsConnected(false);
+      isConnectingRef.current = false;
+      return;
+    }
+
     // Don't try to connect if no conversationId
     if (!conversationId) {
       console.warn('Cannot connect WebSocket without conversation ID');
@@ -970,15 +1001,7 @@ export function useStreamingChatWithCitations({
         isConnectingRef.current = false;
         return;
       }
-      // Get the backend URL from environment or use default
-      const backendHost = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-      const backendUrl = new URL(backendHost);
-      
-      // Determine WebSocket protocol based on backend protocol
-      const protocol = backendUrl.protocol === 'https:' ? 'wss:' : 'ws:';
-      
-      // Construct WebSocket URL pointing to the backend server
-      const wsUrl = `${protocol}//${backendUrl.hostname}:${backendUrl.port || (backendUrl.protocol === 'https:' ? '443' : '8000')}/ws/conversation/${conversationId}`;
+      const wsUrl = websocketUrl(`/ws/conversation/${conversationId}`);
       
       console.log('Starting WebSocket connection to:', wsUrl);
       console.log('Current isConnected state before connection:', isConnected);
@@ -1069,7 +1092,7 @@ export function useStreamingChatWithCitations({
   // Send streaming message via HTTP (fallback)
   const sendStreamingMessageHTTP = useCallback(async (content: string) => {
     try {
-      const response = await fetch(`/api/conversation/${conversationId}/message/stream`, {
+      const response = await fetch(apiUrl(`/api/conversation/${conversationId}/message/stream`), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1093,6 +1116,7 @@ export function useStreamingChatWithCitations({
       }
 
       const decoder = new TextDecoder();
+      let buffer = '';
 
       while (true) {
         const { done, value } = await reader.read();
@@ -1101,19 +1125,31 @@ export function useStreamingChatWithCitations({
           break;
         }
 
-        const chunk = decoder.decode(value);
-        const lines = chunk.split('\n');
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
 
         for (const line of lines) {
-          if (line.startsWith('data: ')) {
+          const trimmedLine = line.trimEnd();
+          if (trimmedLine.startsWith('data: ')) {
             try {
-              const streamingEvent: StreamingEvent = JSON.parse(line.slice(6));
+              const streamingEvent: StreamingEvent = JSON.parse(trimmedLine.slice(6));
               // Use the ref to call the latest version of the handler
               handleStreamingEventRef.current?.(streamingEvent);
             } catch (error) {
               console.error('Error parsing SSE chunk:', error);
             }
           }
+        }
+      }
+
+      const finalChunk = `${buffer}${decoder.decode()}`.trim();
+      if (finalChunk.startsWith('data: ')) {
+        try {
+          const streamingEvent: StreamingEvent = JSON.parse(finalChunk.slice(6));
+          handleStreamingEventRef.current?.(streamingEvent);
+        } catch (error) {
+          console.error('Error parsing final SSE chunk:', error);
         }
       }
     } catch (error) {
@@ -1127,7 +1163,7 @@ export function useStreamingChatWithCitations({
     let mounted = true;
     let connectTimeout: NodeJS.Timeout | null = null;
 
-    if (conversationId && mounted) {
+    if (conversationId && mounted && ENABLE_WEBSOCKET_STREAMING) {
       // Add a small delay to debounce rapid re-renders
       connectTimeout = setTimeout(() => {
         if (mounted) {
@@ -1181,7 +1217,7 @@ export function useStreamingChatWithCitations({
     }
 
     try {
-      const sseUrl = `/api/conversation/${conversationId}/message/stream`;
+      const sseUrl = apiUrl(`/api/conversation/${conversationId}/message/stream`);
       eventSourceRef.current = new EventSource(sseUrl);
 
       eventSourceRef.current.onopen = () => {

--- a/nextjs-fdas/src/lib/api/apiService.ts
+++ b/nextjs-fdas/src/lib/api/apiService.ts
@@ -1,8 +1,6 @@
 import { z } from 'zod';
 import { ApiError, ErrorDetail } from '../errors/ApiError';
-
-// API base URL - would be configured based on environment
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { apiUrl } from './baseUrl';
 
 // Configuration for retries
 const MAX_RETRY_ATTEMPTS = 3;
@@ -50,10 +48,7 @@ class ApiService {
       endpoint = '/' + endpoint;
     }
     
-    // Ensure URL doesn't have duplicated /api
-    const finalUrl = API_BASE_URL.endsWith('/api') 
-      ? `${API_BASE_URL}${endpoint}`
-      : `${API_BASE_URL}${endpoint}`;
+    const finalUrl = apiUrl(endpoint);
       
     console.log(`Sending ${method} request to ${finalUrl}`);
     
@@ -247,10 +242,7 @@ class ApiService {
       endpoint = '/' + endpoint;
     }
     
-    // Ensure URL doesn't have duplicated /api
-    const finalUrl = API_BASE_URL.endsWith('/api') 
-      ? `${API_BASE_URL}${endpoint}`
-      : `${API_BASE_URL}${endpoint}`;
+    const finalUrl = apiUrl(endpoint);
       
     console.log(`Uploading file to ${finalUrl}`);
     
@@ -337,10 +329,7 @@ class ApiService {
       endpoint = '/' + endpoint;
     }
     
-    // Ensure URL doesn't have duplicated /api
-    const finalUrl = API_BASE_URL.endsWith('/api') 
-      ? `${API_BASE_URL}${endpoint}`
-      : `${API_BASE_URL}${endpoint}`;
+    const finalUrl = apiUrl(endpoint);
     
     try {
       const response = await fetch(finalUrl, {

--- a/nextjs-fdas/src/lib/api/baseUrl.ts
+++ b/nextjs-fdas/src/lib/api/baseUrl.ts
@@ -1,0 +1,45 @@
+const DEFAULT_DEVELOPMENT_API_URL = 'http://localhost:8000';
+const DEFAULT_PRODUCTION_API_URL = 'https://cfin-backend.vercel.app';
+
+const stripTrailingSlashes = (value: string) => value.replace(/\/+$/, '');
+
+const configuredApiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
+
+export const API_BASE_URL = stripTrailingSlashes(
+  configuredApiUrl ||
+    (process.env.NODE_ENV === 'production'
+      ? DEFAULT_PRODUCTION_API_URL
+      : DEFAULT_DEVELOPMENT_API_URL)
+);
+
+export const API_ORIGIN_URL = API_BASE_URL.endsWith('/api')
+  ? API_BASE_URL.slice(0, -4)
+  : API_BASE_URL;
+
+export const ENABLE_WEBSOCKET_STREAMING =
+  process.env.NEXT_PUBLIC_ENABLE_WEBSOCKETS === 'true' ||
+  (
+    process.env.NEXT_PUBLIC_ENABLE_WEBSOCKETS !== 'false' &&
+    !API_ORIGIN_URL.includes('.vercel.app')
+  );
+
+export function apiUrl(endpoint: string): string {
+  const normalized = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+
+  if (normalized === '/api') {
+    return `${API_ORIGIN_URL}/api`;
+  }
+
+  if (normalized.startsWith('/api/')) {
+    return `${API_ORIGIN_URL}${normalized}`;
+  }
+
+  return `${API_ORIGIN_URL}/api${normalized}`;
+}
+
+export function websocketUrl(endpoint: string): string {
+  const normalized = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+  const url = new URL(normalized, `${API_ORIGIN_URL}/`);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  return url.toString();
+}

--- a/nextjs-fdas/src/lib/api/conversation.ts
+++ b/nextjs-fdas/src/lib/api/conversation.ts
@@ -1,9 +1,7 @@
 import { Message, Citation } from '@/types';
 import { MessageRequestSchema, ConversationCreateRequestSchema } from '@/validation/schemas';
 import { validateRequest } from '../../lib/validation/api-validation';
-
-// API base URL - would be configured based on environment
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api';
+import { apiUrl } from './baseUrl';
 
 /**
  * Conversation API service
@@ -24,10 +22,7 @@ class ConversationApiService {
       endpoint = '/' + endpoint;
     }
     
-    // Fixed URL construction to prevent duplicated /api
-    const finalUrl = API_BASE_URL.endsWith('/api') 
-      ? `${API_BASE_URL}${endpoint}`
-      : `${API_BASE_URL}/api${endpoint}`;
+    const finalUrl = apiUrl(endpoint);
       
     console.log(`Sending ${method} request to ${finalUrl}`);
     

--- a/nextjs-fdas/src/lib/api/documents.ts
+++ b/nextjs-fdas/src/lib/api/documents.ts
@@ -1,13 +1,11 @@
 import { ProcessedDocument, DocumentUploadResponse, Citation } from '@/types';
 import { apiService } from './apiService';
+import { apiUrl } from './baseUrl';
 import { 
   DocumentUploadResponseSchema, 
   ProcessedDocumentSchema,
   CitationSchema
 } from '@/validation/schemas';
-
-// API base URL - would be configured based on environment
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
 // Function to handle API errors - keeping for backwards compatibility
 const handleApiError = (error: any): never => {
@@ -395,7 +393,7 @@ export const documentsApi = {
       // fetch the actual document content as binary data and create a blob URL
       
       // Fetch the document content as a blob
-      const response = await fetch(`${API_BASE_URL}/api/documents/${documentId}/file`, {
+      const response = await fetch(apiUrl(`/api/documents/${documentId}/file`), {
         method: 'GET',
         headers: {
           'Accept': 'application/pdf',
@@ -460,7 +458,19 @@ export const documentsApi = {
    */
   async getDocumentCitations(documentId: string): Promise<Citation[]> {
     try {
-      const response = await apiService.get<ApiCitation[]>(`/api/documents/${documentId}/citations`);
+      const citationResponse = await fetch(apiUrl(`/api/documents/${documentId}/citations`), {
+        headers: { Accept: 'application/json' },
+      });
+
+      if (citationResponse.status === 404) {
+        return [];
+      }
+
+      if (!citationResponse.ok) {
+        throw new Error(`Failed to load document citations: ${citationResponse.status} ${citationResponse.statusText}`);
+      }
+
+      const response = await citationResponse.json() as ApiCitation[];
       
       // Ensure the response is an array
       if (Array.isArray(response)) {
@@ -484,8 +494,8 @@ export const documentsApi = {
       
       return [];
     } catch (error) {
-      console.error('Error getting document citations:', error);
-      throw handleApiError(error);
+      console.warn('Document citations unavailable:', error);
+      return [];
     }
   },
   

--- a/nextjs-fdas/src/lib/pdf/textSearch.ts
+++ b/nextjs-fdas/src/lib/pdf/textSearch.ts
@@ -129,7 +129,7 @@ export async function searchMultiplePages(
         results.push(result);
       }
     } catch (error) {
-      console.error(`Error searching page ${pageNum}:`, error);
+      console.warn(`Error searching page ${pageNum}:`, error);
     }
   }
 

--- a/nextjs-fdas/src/services/visualizationService.ts
+++ b/nextjs-fdas/src/services/visualizationService.ts
@@ -3,8 +3,7 @@
  */
 
 import { VisualizationData, ChartData, TableData } from '@/types/visualization';
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { apiUrl } from '@/lib/api/baseUrl';
 
 /**
  * Fetch all visualizations for an analysis
@@ -13,7 +12,7 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
  */
 export async function fetchVisualizations(analysisId: string): Promise<VisualizationData> {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/analysis/${analysisId}/visualizations`);
+    const response = await fetch(apiUrl(`/api/analysis/${analysisId}/visualizations`));
     
     if (!response.ok) {
       throw new Error(`Error fetching visualizations: ${response.statusText}`);
@@ -34,7 +33,7 @@ export async function fetchVisualizations(analysisId: string): Promise<Visualiza
  */
 export async function fetchChart(chartId: string): Promise<ChartData> {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/charts/${chartId}`);
+    const response = await fetch(apiUrl(`/api/charts/${chartId}`));
     
     if (!response.ok) {
       throw new Error(`Error fetching chart: ${response.statusText}`);
@@ -55,7 +54,7 @@ export async function fetchChart(chartId: string): Promise<ChartData> {
  */
 export async function fetchTable(tableId: string): Promise<TableData> {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/tables/${tableId}`);
+    const response = await fetch(apiUrl(`/api/tables/${tableId}`));
     
     if (!response.ok) {
       throw new Error(`Error fetching table: ${response.statusText}`);
@@ -76,7 +75,7 @@ export async function fetchTable(tableId: string): Promise<TableData> {
  */
 export async function fetchFinancialMetrics(analysisId: string) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/analysis/${analysisId}/metrics`);
+    const response = await fetch(apiUrl(`/api/analysis/${analysisId}/metrics`));
     
     if (!response.ok) {
       throw new Error(`Error fetching metrics: ${response.statusText}`);
@@ -97,7 +96,7 @@ export async function fetchFinancialMetrics(analysisId: string) {
  */
 export async function fetchPeriodData(analysisId: string) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/analysis/${analysisId}/periods`);
+    const response = await fetch(apiUrl(`/api/analysis/${analysisId}/periods`));
     
     if (!response.ok) {
       throw new Error(`Error fetching period data: ${response.statusText}`);


### PR DESCRIPTION
## Summary
- Add shared `baseUrl.ts` for API origin and websocket streaming defaults.
- Rank numeric citation candidates in `MessageRenderer` for better PDF text search hits.
- Update streaming chat hooks, PDF viewer, and citation context for inline markers.
- Minor workspace/API client adjustments for citation document fetch paths.

## Test plan
- [ ] Stream a chat answer with table citations; clicking `[n]` should highlight the numeric value in the PDF.
- [ ] Verify dev (`localhost:8000`) and production API URLs resolve correctly.
- [ ] Confirm websocket streaming toggles off on Vercel-hosted API origins.

## Stack
- Depends on #23 (`feat/citation-streaming-backend`)


Made with [Cursor](https://cursor.com)